### PR TITLE
Remove .py ending from name when loading module

### DIFF
--- a/tangelo.in
+++ b/tangelo.in
@@ -225,7 +225,9 @@ class Server(object):
             mtime = os.path.getmtime(module)
             if stamp is None or mtime > stamp["mtime"]:
                 tangelo.log("loading new module: " + module)
-                service = imp.load_source(module, module)
+                # Remove .py to get the module name
+                name = module[:-3]
+                service = imp.load_source(name, module)
                 self.modules[module] = {"module": service, "mtime": mtime}
             else:
                 service = stamp["module"]


### PR DESCRIPTION
If the name contains as . then the interrupter treats the part
before the . as a module and warnings that is couldn't be loaded.
