### PR TITLE
Resetting control panel height on collapse - Fixes #227

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,6 +292,7 @@ if(${BUILD_TESTING})
         404-not-found
         200-ok
         geodots-match
+        dynamic-control-panel
     )
 
     # Configure the python test runner.

--- a/testing/web-content-tests/dynamic-control-panel.js
+++ b/testing/web-content-tests/dynamic-control-panel.js
@@ -1,0 +1,31 @@
+/*jslint browser: true */
+/*globals declareTest, compareImages, toImageData, Promise */
+
+declareTest({
+    name: "Control panel size should increase when rows are added to it",
+    url: "/tests/cases/dynamic-control-panel",
+    test: function (page) {
+        "use strict";
+
+        return new Promise(function (deliver) {
+            var before,
+                after;
+
+            window.setTimeout(function () {
+                before = page.evaluate(function () {
+                    return document.getElementById("before").innerText;
+                });
+
+                after = page.evaluate(function () {
+                    return document.getElementById("after").innerText;
+                });
+
+                console.log("expected control panel to grow from 40px to 60px");
+                console.log("before: " + before);
+                console.log("after: " + after);
+
+                deliver(before === "40" && after === "60");
+            }, 1500);
+        });
+    }
+});


### PR DESCRIPTION
This takes care of changes that could happen to the control panel height
dynamically. Would not handle the case where the control panel is changed
while collapsed, not sure how that could be taken care of.
