### PR TITLE
Adding a test case for calling tangelo.accessor with a function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -398,6 +398,7 @@ if(${BUILD_TESTING})
         tangelo-exists
         isFunction
         isBoolean
+        accessorFunction
     )
 
     # A list of Tangelo (i.e. Python) unit tests.  The corresponding .py file

--- a/testing/js-unit-tests/accessorFunction.js
+++ b/testing/js-unit-tests/accessorFunction.js
@@ -1,0 +1,18 @@
+/*globals describe, it, expect, tangelo */
+
+describe("tangelo.accessor", function () {
+    "use strict";
+
+    it("Test accessor wrapper to a function", function () {
+        var data = { x: 1, y: 2 };
+        var addition = function (d) {
+            return d.x + d.y;
+        };
+        
+        var a = tangelo.accessor(addition);
+
+        expect(a(data)).toBe(3);
+
+    });
+
+});


### PR DESCRIPTION
Currently this test fails with:

```
Error: [tangelo.accessor()] I am an undefined accessor - you shouldn't be calling me!
    at Object.tangelo.fatalError (http://localhost/~jbeezley/cluster/js/tangelo.js:36:15)
    at func (http://localhost/~jbeezley/cluster/js/tangelo.js:223:25)
    at null.<anonymous> (http://localhost/~jbeezley/cluster/accessorFunction.js:14:16)
```
