### PR TITLE
changed header function to allow addition of custom headers

### DIFF
--- a/tangelo/tangelo/__init__.py
+++ b/tangelo/tangelo/__init__.py
@@ -16,7 +16,7 @@ def content_type(t=None):
 
 
 def header(h, t=None):
-    r = cherrypy.response.headers[h]
+    r = cherrypy.response.headers.get(h, None)
 
     if t is not None:
         cherrypy.response.headers[h] = t


### PR DESCRIPTION
When adding a custom header the **header** function throws a **KeyError**.  Changed it to use the dict.get function and return None when the header is not already in the response. 
