### PR TITLE
Dendrogram's d3 version compatibility

### DIFF
--- a/src/js/plugin/dendrogram.js
+++ b/src/js/plugin/dendrogram.js
@@ -203,7 +203,7 @@
                 if (!node.parent) {
                     node.parent = node;
                 }
-                if (node.children) {
+                if (node.children && node.children.length) {
                     node.children.forEach(function (d) {
                         d.parent = node;
                         setPosition(d, pos + 10 * that.options.distance(d));


### PR DESCRIPTION
In older versions of d3 (specifically 3.1.4 which is still used by meteor's core d3 package), a bunch of the x's get set to NaN because node.children is an empty array rather than undefined.  

I think this also just makes it generally more robust.
