### PR TITLE
adding cherrypy.config to girder import

### DIFF
--- a/tangelo/tangelo/server.py
+++ b/tangelo/tangelo/server.py
@@ -94,7 +94,7 @@ class Tangelo(object):
 
             plugins = model_importer.ModelImporter().model('setting').get(
                 constants.SettingKey.PLUGINS_ENABLED, default=())
-            plugin_utilities.loadPlugins(plugins, root)
+            plugin_utilities.loadPlugins(plugins, root, cherrypy.config)
 
         except ImportError:
             # Ok, just don't mount it.


### PR DESCRIPTION
This change seems to be necessary to mount the current version of girder correctly.
