### PR TITLE
Fix CherryPy version to 3.2.4

### DIFF
--- a/tangelo/setup.py.in
+++ b/tangelo/setup.py.in
@@ -49,5 +49,5 @@ distutils.core.setup(name="tangelo",
                      "with the power of Python",
                      license="Apache License, Version 2.0",
                      platforms=["Linux", "OS X", "Windows"],
-                     install_requires=["cherrypy >= 3.2",
+                     install_requires=["cherrypy == 3.2.4",
                                        "Twisted >= 13.2"])


### PR DESCRIPTION
The release of 3.3.0 was automatically picked up and does not
seem to be able to serve over SSL.
