### PR TITLE
put websockets in blocking mode when writing

### DIFF
--- a/tangelo/tangelo/ws4py/websocket.py
+++ b/tangelo/tangelo/ws4py/websocket.py
@@ -240,6 +240,9 @@ class WebSocket(object):
         if self.terminated or self.sock is None:
             raise RuntimeError("Cannot send on a terminated websocket")
 
+        # blocking mode, never throw WantWriteError
+        self.sock.setblocking(1)
+
         self.sock.sendall(b)
 
     def send(self, payload, binary=False):


### PR DESCRIPTION
We were encountering a OpenSSL.SSL.WantWriteError on arbor.kitware.com when attempting to send a relatively large image to the client over wss.  This change solves the problem.
