### PR TITLE
No need to duplicate girder config

### DIFF
--- a/tangelo/bin/tangelo.in
+++ b/tangelo/bin/tangelo.in
@@ -83,24 +83,6 @@ def shutdown(signum, frame):
 def start():
     sys.stderr.write("starting tangelo...")
 
-    # Set up the global configuration.  This includes the hostname and port
-    # number as specified in the CMake phase.
-    #
-    # Whether to log directly to the screen has to do with whether we are
-    # daemonizing - if we are, we want to suppress the output, and if we are
-    # not, we want to see everything.
-    try:
-        cherrypy.config.update({"environment": "production",
-                                "log.error_file": logfile,
-                                "log.screen": not daemonize,
-                                "server.socket_host": hostname,
-                                "server.socket_port": port,
-                                "error_page.default": tangelo.server.Tangelo.error_page})
-    except IOError as e:
-        print >>sys.stderr, "failed"
-        print >>sys.stderr, "error with config file %s: %s" % (e.filename, e.strerror)
-        return 1
-
     # If we are daemonizing, do it here, before anything gets started.  We have
     # to set this up in a certain way:
     #
@@ -194,6 +176,24 @@ def start():
                                                "tools.treat_url.on": True},
                                          "/favicon.ico": {"tools.staticfile.on": True,
                                                           "tools.staticfile.filename": sys.prefix + "/share/tangelo/tangelo.ico"}})
+
+    # Set up the global configuration.  This includes the hostname and port
+    # number as specified in the CMake phase.
+    #
+    # Whether to log directly to the screen has to do with whether we are
+    # daemonizing - if we are, we want to suppress the output, and if we are
+    # not, we want to see everything.
+    try:
+        cherrypy.config.update({"environment": "production",
+                                "log.error_file": logfile,
+                                "log.screen": not daemonize,
+                                "server.socket_host": hostname,
+                                "server.socket_port": port,
+                                "error_page.default": tangelo.server.Tangelo.error_page})
+    except IOError as e:
+        print >>sys.stderr, "failed"
+        print >>sys.stderr, "error with config file %s: %s" % (e.filename, e.strerror)
+        return 1
 
     # Try to drop privileges if requested, since we've bound to whatever port
     # superuser privileges were needed for already.

--- a/tangelo/tangelo/girder.py
+++ b/tangelo/tangelo/girder.py
@@ -3,35 +3,11 @@ from __future__ import absolute_import
 import cherrypy
 import os
 
+
 class TangeloGirder(object):
     exposed = True
 
     def __init__(self, host, port):
-        # The girder module expects these cherrypy config options to be set
-        # already by the time it's imported.
-        cherrypy.config.update({
-            "sessions": {"cookie_lifetime": 180},
-            "server": {"mode": "development"},
-            "database": {
-                "host": host,
-                "port": port,
-                "user": "",
-                "password": "",
-                "database": "girder"
-                },
-            "users": {
-                "email_regex": "^[\w\.\-]*@[\w\.\-]*\.\w+$",
-                "login_regex": "^[a-z][\da-z\-]{3}[\da-z\-]*$",
-                "login_description": "Login be at least 4 characters, start with a letter, and may only contain letters, numbers, or dashes.",
-                "password_regex": ".{6}.*",
-                "password_description": "Password must be at least 6 characters."
-                },
-            "auth": {
-                "hash_alg": "bcrypt",
-                "bcrypt_rounds": 12
-                }
-            })
-
         # Now import the girder modules.  If this fails, it's up to the
         # administrator to make sure Girder is installed and on the PYTHONPATH.
         import girder.events
@@ -51,10 +27,16 @@ class TangeloGirder(object):
             constants.SettingKey.PLUGINS_ENABLED, default=())
         plugin_utilities.loadPlugins(plugins, self, cherrypy.config)
 
-        self.config = {"/": {"request.dispatch": cherrypy.dispatch.MethodDispatcher(),
-                             "tools.staticdir.root": self.root_dir},
-                       "/static": {"tools.staticdir.on": "True",
-                                   "tools.staticdir.dir": "clients/web/static"}}
+        self.config = {
+            "/": {
+                "request.dispatch": cherrypy.dispatch.MethodDispatcher(),
+                "tools.staticdir.root": self.root_dir
+            },
+            "/static": {
+                "tools.staticdir.on": "True",
+                "tools.staticdir.dir": "clients/web/static"
+            }
+        }
 
     def GET(self):
         return cherrypy.lib.static.serve_file(


### PR DESCRIPTION
As long as we set the tangelo cherrypy config after the girder plugin is loaded, it is safe to let girder load its config in its own way. Without moving the tangelo cherrypy config, girder would override things (most notably the server port).
