### PR TITLE
Customizable osm tile url for geojs plugins

### DIFF
--- a/docs/tangelo-js.rst
+++ b/docs/tangelo-js.rst
@@ -762,6 +762,7 @@ provide convenient behaviors or to implement common visualization methods.  See
     </examples/geojsMap>`.
 
     :param integer spec.zoom: The initial zoom level of the map.
+    :param string spec.tileURL: The base url for an openstreetmap compatible tile server.
 
     The widget also contains the following public methods for drawing on the
     map.

--- a/src/js/plugin/geojsMap.js
+++ b/src/js/plugin/geojsMap.js
@@ -13,7 +13,8 @@
             // etc.
             zoom: 3,
             width: null,
-            height: null
+            height: null,
+            tileURL: undefined
         },
         latlng2display: function (pt) {
             return this.svgLayer.renderer().worldToDisplay(pt);
@@ -43,7 +44,7 @@
                 },
                 that = this;
             this._map = geo.map(opts);
-            this._map.createLayer('osm');
+            this._map.createLayer('osm', { baseUrl: this.options.tileURL });
             this.svgLayer = this._map.createLayer('feature', {'renderer': 'd3Renderer'});
             this.svgGroup = this.svgLayer.renderer().canvas();
 
@@ -65,6 +66,9 @@
             this._map.resize(0, 0, w, h);
         },
         _setOption: function (key, value) {
+            if (key === 'tileURL' && this._map) {
+                throw "Cannot set tileURL after map creation.";
+            }
             this.options[key] = value;
             if (key === 'width' || key === 'height') {
                 this._resize();


### PR DESCRIPTION
This provides an additional option to the geojs plugins to override the default tile server.  For the moment, it is useful for creating a local proxy to the default tile server when the application is hosted over https.
