### PR TITLE
``--examples`` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ versioning](http://semver.org).
 - Serverside and command line version tests
 - Cross-platform generation of ``tangelo`` and ``tangelo-passwd`` executable
   files (tested on Linux, Windows, and OS X)
+- ``--examples`` flag causes example applications to be served; default web root
+  is now ``.`` (i.e. directory from which Tangelo was invoked)
 
 ### Changed
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,9 +45,9 @@ Quick Start
 
    (On UNIX systems you may need to do this as root, or with ``sudo``.)
 
-3. Issue this command to start up a Tangelo server: ::
+3. Issue this command to start Tangelo, serving the example pack: ::
 
-    tangelo
+    tangelo --examples
 
 4. Visit your Tangelo instance at http://localhost:8080.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -104,7 +104,7 @@ tangelo-users@public.kitware.com.
 
 If all has gone well, you can now try to run Tangelo, using this command: ::
 
-    ./venv/bin/tangelo
+    ./venv/bin/tangelo --examples
 
 The Tangelo executable comes from installing the built Tangelo Python package
 into the development virtual environment, so the command assumes you are in the
@@ -116,7 +116,7 @@ welcome message along with the Tangelo Sunrise.  If instead you receive an error
 message about port 8080 not being free, you may need to launch Tangelo on a
 different port, using a command similar to the following: ::
 
-    ./venv/bin/tangelo --port 9090
+    ./venv/bin/tangelo --examples --port 9090
 
 Running the Test Suites
 -----------------------

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -15,6 +15,9 @@ The simplest way to launch a Tangelo server is to use this command: ::
 
     tangelo
 
+(This command causes Tangelo to begin serving content out of the current
+directory on the default port, 8080.)
+
 Tangelo's runtime behaviors are specified via configuration file and command
 line options.  Tangelo configuration files are YAML files representing a
 key-value store ("associative array" in YAML jargon) at the top level.  Each
@@ -78,7 +81,7 @@ hostname         The hostname interface on which to listen for connections      
 
 port             The port number on which to listen for connections                  ``8080``
 
-root             The path to the directory to be served by Tangelo as the web root   ``/usr/share/tangelo/www`` [#root]_
+root             The path to the directory to be served by Tangelo as the web root   ``.`` [#root]_
 
 drop-privileges  Whether to drop privileges when started as the superuser            ``True``
 
@@ -97,9 +100,8 @@ cert             The path to the SSL certificate                                
 
 .. rubric:: Footnotes
 
-.. [#root] The first component of this path may vary by platform.  Technically,
-    the path begins with the Python value stored in ``sys.prefix``; in a Unix
-    system, this value is */usr*, yielding the default path shown here.
+.. [#root] This is to say, Tangelo serves from the directory in which it was
+    invoked by default.
 
 .. [#usergroup] Your Unix system may already have a user named "nobody" which
     has the least possible level of permissions.  The theory is that system daemons
@@ -159,8 +161,8 @@ The corresponding configuration file might look like this:
     root: /srv/tangelo
 
 This file should be saved to ``/etc/tangelo.conf``, and then Tangelo can be
-launched with a command like ``tangelo -c /etc/tangelo.conf`` (the ``sudo`` may
-be necessary to allow for port 80 to be bound).
+launched with a command like ``tangelo -c /etc/tangelo.conf`` (running the
+command with ``sudo`` may be necessary to allow for port 80 to be bound).
 
 Running Tangelo as a System Service
 ===================================

--- a/docs/tangelo-manpage.rst
+++ b/docs/tangelo-manpage.rst
@@ -26,7 +26,7 @@ Optional argument                  Effect
 -u USERNAME, --user USERNAME       specifies the user to run as when root privileges are dropped
 -g GROUPNAME, --group GROUPNAME    specifies the group to run as when root privileges are dropped
 -r DIR, --root DIR                 the directory from which Tangelo will serve content
---vtkpython FILE                   the vtkpython executable, for use with the vtkweb service (default: "vtkpython")
+--examples                         serve the Tangelo example applications
 --verbose, -v                      display extra information as Tangelo starts up
 --version                          display Tangelo version number
 --key FILE                         the path to the SSL key. You must also specify --cert to serve content over https.
@@ -36,13 +36,18 @@ Optional argument                  Effect
 Example Usage
 =============
 
-To start a Tangelo server with the default configuration: ::
+To start a Tangelo server with the default configuration, serving from the
+current directory: ::
 
     tangelo
 
 This starts Tangelo on port 8080.
 
+To serve the example applications that come bundled with Tangelo: ::
+
+    tangelo --examples
+
 To control particular options, such as the port number (overriding the value
 specified in the config) file: ::
 
-    tangelo start --port 9090
+    tangelo --port 9090

--- a/tangelo/tangelo/__main__.py
+++ b/tangelo/tangelo/__main__.py
@@ -178,6 +178,7 @@ def main():
     p.add_argument("--key", type=str, default=None, metavar="FILE", help="the path to the SSL key.  You must also specify --cert to serve content over https.")
     p.add_argument("--cert", type=str, default=None, metavar="FILE", help="the path to the SSL certificate.  You must also specify --key to serve content over https.")
     p.add_argument("--plugin-config", type=str, default=None, metavar="PATH", help="path to plugin configuration file")
+    p.add_argument("--examples", action="store_true", default=None, help="Serve the Tangelo example applications")
     args = p.parse_args()
 
     # If version flag is present, print the version number and exit.
@@ -196,7 +197,21 @@ def main():
 
     if args.no_sessions and args.sessions:
         tangelo.log_error("ERROR", "can't specify both --sessions (-s) and --no-sessions (-ns) together")
-        sys.exit(1)
+        return 1
+
+    if args.examples:
+        stop = False
+
+        if args.root:
+            tangelo.log_error("ERROR", "can't specify both --examples and --root (-r) together")
+            stop = True
+
+        if args.plugin_config:
+            tangelo.log_error("ERROR", "can't specify both --examples and --plugin-config")
+            stop = True
+
+        if stop:
+            return 1
 
     # Figure out where this is being called from - that will be useful for a
     # couple of purposes.
@@ -303,29 +318,28 @@ def main():
     # We need a web root - use the installed example web directory as a
     # fallback.  This might be found in a few different places, so try them one
     # by one until we find one that exists.
-    #
-    # TODO(choudhury): shouldn't we *only* check the invocation_dir option?  We
-    # shouldn't pick up a stray web directory that happens to be found in /usr
-    # if we're invoking tangelo from a totally different location.
     root = args.root or config.root
     if root:
         root = tangelo.util.expandpath(root)
-    else:
+    elif args.examples:
+        # The /usr/local/... path is a workaround for homebrew on OSX, which
+        # places Python is a very strange place that doesn't play well with
+        # standard installations.
         default_paths = map(tangelo.util.expandpath, [sys.prefix + "/share/tangelo/web",
                                                       invocation_dir + "/share/tangelo/web",
                                                       "/usr/local/share/tangelo/web"])
-        tangelo.log_info("TANGELO", "Looking for default web content path")
+        tangelo.log_info("TANGELO", "Looking for examples package")
         for path in default_paths:
             tangelo.log_info("TANGELO", "Trying %s" % (path))
             if os.path.exists(path):
                 root = path
                 break
 
-        # TODO(choudhury): by default, should we simply serve from the current
-        # directory?  This is how SimpleHTTPServer works, for example.
         if not root:
-            tangelo.log_error("TANGELO", "could not find default web root directory")
+            tangelo.log_error("ERROR", "could not find examples package")
             return 1
+    else:
+        root = tangelo.util.expandpath(".")
 
     tangelo.log("TANGELO", "Serving content from %s" % (root))
 


### PR DESCRIPTION
Adds ``--examples`` flag to Tangelo.  This flag causes Tangelo to start up serving the bundled example applications (including the Tangelo Sunrise).

If neither ``--examples`` nor ``--root``/``-r`` is given, then Tangelo serves content from the current directory.  This is more in line with using Tangelo as an application driver, rather than general purpose web server.

Giving ``--examples`` and ``--root``/``-r`` or ``--plugin-config`` is considered an error, since ``--examples`` more or less puts Tangelo into a special demo mode.