### PR TITLE
tangelo.util.yaml_safe_load()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ versioning](http://semver.org).
 - ``tangelo.plugin_config()`` works
 - Python module path behaves correctly in plugin web directories
 - ``tangelo.server.analyze()`` works better, especially for plugin development
+- Informational log output now goes unilaterally to ``sys.stderr`` while access
+  logs go to ``sys.stdout``
 
 ### Security
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -604,9 +604,9 @@ module.exports = function (grunt) {
                     grunt.fail.fatal("Could not launch Tangelo");
                 }
 
-                process.stderr.setEncoding("utf8");
+                process.stdout.setEncoding("utf8");
 
-                process.stderr.on("data", function (chunk) {
+                process.stdout.on("data", function (chunk) {
                     var complete = chunk.slice(-1) === "\n",
                         lines,
                         i,
@@ -633,7 +633,7 @@ module.exports = function (grunt) {
                     }
                 });
 
-                process.stderr.on("end", function () {
+                process.stdout.on("end", function () {
                     if (stopping) {
                         return;
                     }
@@ -649,7 +649,7 @@ module.exports = function (grunt) {
 
                 process.kill();
 
-                process.stderr.on("end", function () {
+                process.stdout.on("end", function () {
                     done();
                 });
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -604,9 +604,9 @@ module.exports = function (grunt) {
                     grunt.fail.fatal("Could not launch Tangelo");
                 }
 
-                process.stdout.setEncoding("utf8");
+                process.stderr.setEncoding("utf8");
 
-                process.stdout.on("data", function (chunk) {
+                process.stderr.on("data", function (chunk) {
                     var complete = chunk.slice(-1) === "\n",
                         lines,
                         i,
@@ -633,7 +633,7 @@ module.exports = function (grunt) {
                     }
                 });
 
-                process.stdout.on("end", function () {
+                process.stderr.on("end", function () {
                     if (stopping) {
                         return;
                     }
@@ -649,7 +649,7 @@ module.exports = function (grunt) {
 
                 process.kill();
 
-                process.stdout.on("end", function () {
+                process.stderr.on("end", function () {
                     done();
                 });
 

--- a/tangelo/tangelo/__init__.py
+++ b/tangelo/tangelo/__init__.py
@@ -41,8 +41,8 @@ def log(section, message=None, color=None):
         section = "TANGELO"
 
     if not tangelo.util.windows() and color is not None:
-        section = "%s%s%s" % (color, section, "\033[0m")
-        message = "%s%s%s" % (color, message, "\033[0m")
+        section = "%s%s" % (color, section)
+        message = "%s%s" % (message, "\033[0m")
 
     cherrypy.log(str(message), section)
 

--- a/tangelo/tangelo/__main__.py
+++ b/tangelo/tangelo/__main__.py
@@ -8,7 +8,6 @@ import signal
 import sys
 import tangelo.util
 import ws4py.server
-import yaml
 
 import tangelo
 import tangelo.server
@@ -112,11 +111,7 @@ class Config(object):
             self.load(filename)
 
     def load(self, filename):
-        with open(filename) as f:
-            d = yaml.safe_load(f.read())
-
-        if not isinstance(d, dict):
-            raise TypeError("Config file %s does not contain a top-level associative array")
+        d = tangelo.util.yaml_safe_load(filename, dict)
 
         self.access_auth = d.get("access-auth")
         self.drop_privileges = d.get("drop-privileges")
@@ -250,10 +245,10 @@ def main():
         ok = False
         config = Config(cfg_file)
         ok = True
-    except (IOError, TypeError) as e:
-        tangelo.log_error("TANGELO", "error: %s" % (e))
-    except yaml.YAMLError as e:
-        tangelo.log_error("TANGELO", "error while parsing config file: %s" % (e))
+    except (IOError, ValueError) as e:
+        tangelo.log_error("ERROR", e)
+    except TypeError as e:
+        tangelo.log_error("ERROR", "Config file does not contain associative array at top level")
     finally:
         if not ok:
             return 1

--- a/tangelo/tangelo/__main__.py
+++ b/tangelo/tangelo/__main__.py
@@ -189,6 +189,19 @@ def main():
         print tangelo_version
         return 0
 
+    # Make all logging go to stdout instead of stderr.
+    #
+    # The "cherrypy.error" logger contains two handlers by default - a
+    # NullHandler, and a StreamHandler that writes to stderr.  This piece of
+    # code simply removes the StreamHandler, modifies it to write to stdout, and
+    # then replaces it.
+    import logging
+    logger = logging.getLogger("cherrypy.error")
+    handler = logger.handlers[1]
+    logger.removeHandler(handler)
+    handler.stream = sys.stdout
+    logger.addHandler(handler)
+
     # Make sure user didn't specify conflicting flags.
     if args.access_auth and args.no_access_auth:
         tangelo.log_error("ERROR", "can't specify both --access-auth (-a) and --no-access-auth (-na) together")

--- a/tangelo/tangelo/__main__.py
+++ b/tangelo/tangelo/__main__.py
@@ -432,14 +432,10 @@ def main():
                                                           "tools.staticfile.filename": sys.prefix + "/share/tangelo/tangelo.ico"}})
 
     # Set up the global configuration.
-    try:
-        cherrypy.config.update({"environment": "production",
-                                "log.screen": True,
-                                "server.socket_host": hostname,
-                                "server.socket_port": port})
-    except IOError as e:
-        tangelo.log_error("TANGELO", "problem with config file %s: %s" % (e.filename, e.strerror))
-        return 1
+    cherrypy.config.update({"environment": "production",
+                            "log.screen": True,
+                            "server.socket_host": hostname,
+                            "server.socket_port": port})
 
     # Try to drop privileges if requested, since we've bound to whatever port
     # superuser privileges were needed for already.

--- a/tangelo/tangelo/__main__.py
+++ b/tangelo/tangelo/__main__.py
@@ -189,19 +189,6 @@ def main():
         print tangelo_version
         return 0
 
-    # Make all logging go to stdout instead of stderr.
-    #
-    # The "cherrypy.error" logger contains two handlers by default - a
-    # NullHandler, and a StreamHandler that writes to stderr.  This piece of
-    # code simply removes the StreamHandler, modifies it to write to stdout, and
-    # then replaces it.
-    import logging
-    logger = logging.getLogger("cherrypy.error")
-    handler = logger.handlers[1]
-    logger.removeHandler(handler)
-    handler.stream = sys.stdout
-    logger.addHandler(handler)
-
     # Make sure user didn't specify conflicting flags.
     if args.access_auth and args.no_access_auth:
         tangelo.log_error("ERROR", "can't specify both --access-auth (-a) and --no-access-auth (-na) together")

--- a/tangelo/tangelo/util.py
+++ b/tangelo/tangelo/util.py
@@ -28,7 +28,7 @@ def yaml_safe_load(filename, type=None):
         data = type()
 
     if type is not None and not isinstance(data, type):
-        raise TypeError
+        raise TypeError(type.__name__)
 
     return data
 
@@ -44,18 +44,14 @@ class PluginConfig(object):
             self.load(filename)
 
     def load(self, filename):
-        with open(filename) as f:
-            try:
-                plugins = yaml.safe_load(f.read())
-            except yaml.YAMLError as e:
-                raise ValueError(e.message)
+        try:
+            plugins = yaml_safe_load(filename, list)
+        except TypeError:
+            raise TypeError("plugin config file %s does not contain a top-level list" % (filename))
 
         # This enables an empty file to represent an empty list instead.
         if plugins is None:
             plugins = []
-
-        if not isinstance(plugins, list):
-            raise TypeError("plugin config file %s does not contain a top-level list" % (filename))
 
         for i, p in enumerate(plugins):
             if "name" not in p:

--- a/tests/config/bad-config.yaml
+++ b/tests/config/bad-config.yaml
@@ -1,0 +1,8 @@
+- This
+
+is: a badly
+
+specified
+
+- yaml
+- file

--- a/tests/config/list-config.yaml
+++ b/tests/config/list-config.yaml
@@ -1,0 +1,8 @@
+- This
+- is a valid
+- YAML file,
+- but it is not a
+- valid Tangelo config file
+- because it contains a list at the top level
+- instead of
+- an associative array.

--- a/tests/fixture/__init__.py
+++ b/tests/fixture/__init__.py
@@ -74,11 +74,11 @@ def start_tangelo():
                                                           "--root", "tests/web",
                                                           "--plugin-config", "venv/share/tangelo/plugin/plugin.conf",
                                                           "--list-dir"],
-                               stderr=subprocess.PIPE)
+                               stdout=subprocess.PIPE)
 
     buf = []
     while True:
-        line = process.stderr.readline()
+        line = process.stdout.readline()
         buf.append(line)
 
         if line.rstrip().endswith("ENGINE Bus STARTED"):

--- a/tests/fixture/__init__.py
+++ b/tests/fixture/__init__.py
@@ -74,11 +74,12 @@ def start_tangelo():
                                                           "--root", "tests/web",
                                                           "--plugin-config", "venv/share/tangelo/plugin/plugin.conf",
                                                           "--list-dir"],
-                               stdout=subprocess.PIPE)
+                               stdout=subprocess.PIPE,
+                               stderr=subprocess.PIPE)
 
     buf = []
     while True:
-        line = process.stdout.readline()
+        line = process.stderr.readline()
         buf.append(line)
 
         if line.rstrip().endswith("ENGINE Bus STARTED"):

--- a/tests/get_free_port.py
+++ b/tests/get_free_port.py
@@ -2,12 +2,8 @@ import tangelo.util
 
 
 def test_get_free_port():
-    for _ in xrange(100):
+    for _ in xrange(1000):
         free_port = tangelo.util.get_free_port()
         print "Got free port: %d" % (free_port)
 
-        yield check_port, free_port
-
-
-def check_port(port):
-    assert port > 1024
+        assert free_port > 1024

--- a/tests/tangelo-config.py
+++ b/tests/tangelo-config.py
@@ -11,3 +11,15 @@ def test_bad_config():
 
     assert len(stdout) > 1
     assert signal in stdout[1]
+
+
+def test_non_dict_config():
+    (code, stdout, stderr) = fixture.run_tangelo("-c", "tests/config/list-config.yaml")
+
+    signal = "does not contain associative array"
+
+    print "Expected: '%s' in second line of log" % (signal)
+    print "Received: %s" % (stdout[1] if len(stdout) > 1 else "")
+
+    assert len(stdout) > 1
+    assert signal in stdout[1]

--- a/tests/tangelo-config.py
+++ b/tests/tangelo-config.py
@@ -1,0 +1,11 @@
+import fixture
+
+
+def test_bad_config():
+    (code, stdout, stderr) = fixture.run_tangelo("-c", "tests/config/bad-config.yaml")
+
+    print "Expected: 'ERROR while parsing' in log"
+    print "Received: %s" % (stdout[1] if len(stdout) > 1 else "(nothing)")
+
+    assert len(stdout) > 1
+    assert "ERROR while parsing" in stdout[1]

--- a/tests/tangelo-config.py
+++ b/tests/tangelo-config.py
@@ -7,10 +7,10 @@ def test_bad_config():
     signal = "ERROR while parsing"
 
     print "Expected: '%s' in second line of log" % (signal)
-    print "Received: %s" % (stdout[1] if len(stdout) > 1 else "")
+    print "Received: %s" % (stderr[1] if len(stderr) > 1 else "")
 
-    assert len(stdout) > 1
-    assert signal in stdout[1]
+    assert len(stderr) > 1
+    assert signal in stderr[1]
 
 
 def test_non_dict_config():
@@ -19,7 +19,7 @@ def test_non_dict_config():
     signal = "does not contain associative array"
 
     print "Expected: '%s' in second line of log" % (signal)
-    print "Received: %s" % (stdout[1] if len(stdout) > 1 else "")
+    print "Received: %s" % (stderr[1] if len(stderr) > 1 else "")
 
-    assert len(stdout) > 1
-    assert signal in stdout[1]
+    assert len(stderr) > 1
+    assert signal in stderr[1]

--- a/tests/tangelo-config.py
+++ b/tests/tangelo-config.py
@@ -4,8 +4,10 @@ import fixture
 def test_bad_config():
     (code, stdout, stderr) = fixture.run_tangelo("-c", "tests/config/bad-config.yaml")
 
-    print "Expected: 'ERROR while parsing' in log"
-    print "Received: %s" % (stdout[1] if len(stdout) > 1 else "(nothing)")
+    signal = "ERROR while parsing"
+
+    print "Expected: '%s' in second line of log" % (signal)
+    print "Received: %s" % (stdout[1] if len(stdout) > 1 else "")
 
     assert len(stdout) > 1
-    assert "ERROR while parsing" in stdout[1]
+    assert signal in stdout[1]


### PR DESCRIPTION
Replacing ``yaml.safe_load()`` with ``tangelo.util.yaml_safe_load()`` wherever possible.

Closes #456.