### PR TITLE
[hotfix] Fixing bad search logic

### DIFF
--- a/tangelo/tangelo/__main__.py
+++ b/tangelo/tangelo/__main__.py
@@ -84,6 +84,14 @@ def shutdown(signum, frame):
     tangelo.log_success("TANGELO", "Be seeing you.")
 
 
+def get_invocation_dir():
+    invocation_dir = os.path.join(os.path.dirname(__file__), "..", "..", "..")
+    if platform.system() == "Windows":
+        return os.path.abspath(invocation_dir)
+    else:
+        return os.path.abspath(os.path.join(invocation_dir, ".."))
+
+
 def main():
     p = argparse.ArgumentParser(description="Start a Tangelo server.")
     p.add_argument("-c", "--config", type=str, default=None, metavar="FILE", help="specifies configuration file to use")
@@ -125,9 +133,7 @@ def main():
 
     # Figure out where this is being called from - that will be useful for a
     # couple of purposes.
-    #
-    # invocation_dir = os.path.abspath(os.path.dirname(os.path.abspath(__file__)) + "/..")
-    invocation_dir = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "..", ".."))
+    invocation_dir = get_invocation_dir()
 
     # Before extracting the other arguments, compute a configuration dictionary.
     # If --no-config was specified, this will be the empty dictionary;

--- a/tangelo/tangelo/__main__.py
+++ b/tangelo/tangelo/__main__.py
@@ -125,7 +125,9 @@ def main():
 
     # Figure out where this is being called from - that will be useful for a
     # couple of purposes.
-    invocation_dir = os.path.abspath(os.path.dirname(os.path.abspath(__file__)) + "/..")
+    #
+    # invocation_dir = os.path.abspath(os.path.dirname(os.path.abspath(__file__)) + "/..")
+    invocation_dir = os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..", "..", ".."))
 
     # Before extracting the other arguments, compute a configuration dictionary.
     # If --no-config was specified, this will be the empty dictionary;
@@ -236,15 +238,10 @@ def main():
     if root:
         root = tangelo.util.expandpath(root)
     else:
-        default_paths = map(tangelo.util.expandpath, [sys.prefix + "/share/tangelo/web",
-                                                      invocation_dir + "/share/tangelo/web",
-                                                      "/usr/local/share/tangelo/web"])
-        tangelo.log_info("TANGELO", "Looking for default web content path")
-        for path in default_paths:
-            tangelo.log_info("TANGELO", "Trying %s" % (path))
-            if os.path.exists(path):
-                root = path
-                break
+        root = tangelo.util.expandpath(invocation_dir + "/share/tangelo/web")
+        tangelo.log_info("TANGELO", "Looking for default web content path in %s" % (root))
+        if not os.path.exists(root):
+            root = None
 
         # TODO(choudhury): by default, should we simply serve from the current
         # directory?  This is how SimpleHTTPServer works, for example.
@@ -256,16 +253,10 @@ def main():
 
     # Compute a default plugin configuration if it was not supplied.
     if args.plugin_config is None:
-        plugin_cfg_file = None
-        default_paths = map(tangelo.util.expandpath, [sys.prefix + "/share/tangelo/plugin/plugin.conf",
-                                                      invocation_dir + "/share/tangelo/plugin/plugin.conf",
-                                                      "/usr/local/share/tangelo/plugin/plugin.conf"])
-        tangelo.log_info("TANGELO", "Looking for default plugin configuration file")
-        for path in default_paths:
-            tangelo.log_info("TANGELO", "Trying %s" % (path))
-            if os.path.exists(path):
-                plugin_cfg_file = path
-                break
+        plugin_cfg_file = tangelo.util.expandpath(invocation_dir + "/share/tangelo/plugin/plugin.conf")
+        tangelo.log_info("TANGELO", "Looking for default plugin configuration file in %s" % (plugin_cfg_file))
+        if not os.path.exists(plugin_cfg_file):
+            plugin_cfg_file = None
     else:
         plugin_cfg_file = tangelo.util.expandpath(args.plugin_config)
 


### PR DESCRIPTION
This fixes a long-standing bug where Tangelo was being directed to look in the wrong place for the reasonable yet general default location for the example pack materials, and example plugin config file.

This also removes the need to insert a special case for homebrew on OSX, as the correct logic actually encompasses Linux, OSX, Homebrew, and now Windows as well. 