### PR TITLE
[WIP] Added a tangelo.import_local function.

### DIFF
--- a/tangelo/tangelo/__init__.py
+++ b/tangelo/tangelo/__init__.py
@@ -287,7 +287,8 @@ def import_local(module, path='.'):
                    (module).py must exist in the relative path.
     :param path: the relative path to the directory of the script with the
                  calling function.  An absolute path can also be specified,
-                 but it isn't recommended.
+                 but it isn't recommended, because absolute paths will not be
+                 portable.
     :returns: the loaded module.
     """
     global localModuleCache

--- a/tangelo/tangelo/__init__.py
+++ b/tangelo/tangelo/__init__.py
@@ -300,6 +300,9 @@ def import_local(module, path='.'):
     modpath = os.path.join(path, module + '.py')
     if not os.path.exists(modpath):
         raise 'Error: can\'t locate python file at %s' % (modpath)
-    imported = localModuleCache.get(modpath)
+    # We want to refer to the original python module of a parent for purposes
+    # of tracking changed modules.
+    parent = caller.__file__.rsplit('.', 1)[0] + '.py'
+    imported = localModuleCache.get(modpath, parent)
     frame.f_globals[module] = imported
     return imported

--- a/tangelo/tangelo/__main__.py
+++ b/tangelo/tangelo/__main__.py
@@ -427,6 +427,7 @@ def main():
     # Create an instance of the main handler object.
     module_cache = tangelo.util.ModuleCache()
     tangelo_server = tangelo.server.Tangelo(module_cache=module_cache, plugins=plugins)
+    tangelo.localModuleCache = module_cache
     rootapp = cherrypy.Application(tangelo_server, "/")
 
     # Place an AuthUpdate handler in the Tangelo object if access authorization

--- a/tangelo/tangelo/util.py
+++ b/tangelo/tangelo/util.py
@@ -142,12 +142,26 @@ class ModuleCache(object):
         self.config = config
         self.modules = {}
 
-    def get(self, module):
+    def getMTimeWithChildren(self, module):
+        """
+        Get the latest mtime of this module or any of its children.
+
+        :param module: the path of the module.
+        :returns: the latest mtime of the module and its children.
+        """
+        mtime = os.path.getmtime(module)
+        if module in self.modules:
+            for child in self.modules[module].get("children", {}):
+                if os.path.exists(child):
+                    mtime = max(mtime, self.getMTimeWithChildren(child))
+        return mtime
+
+    def get(self, module, parent=None):
         # Import the module if not already imported previously (or if the module
         # to import, or its configuration file, has been updated since the last
         # import).
         stamp = self.modules.get(module)
-        mtime = os.path.getmtime(module)
+        mtime = self.getMTimeWithChildren(module)
 
         config_file = module[:-2] + "yaml"
         config_mtime = None
@@ -157,6 +171,7 @@ class ModuleCache(object):
                 config_mtime = os.path.getmtime(config_file)
 
         if (stamp is None or
+                "mtime" not in stamp or
                 mtime > stamp["mtime"] or
                 (config_mtime is not None and
                  config_mtime > stamp["mtime"])):
@@ -186,8 +201,16 @@ class ModuleCache(object):
 
             # Load the module.
             service = imp.load_source(name, module)
-            self.modules[module] = {"module": service,
-                                    "mtime": max(mtime, config_mtime)}
+            if module not in self.modules:
+                self.modules[module] = {}
+            self.modules[module]["module"] = service
+            self.modules[module]["mtime"] = max(mtime, config_mtime)
+            if parent:
+                if parent not in self.modules:
+                    self.modules[parent] = {"children": {}}
+                if "children" not in self.modules[parent]:
+                    self.modules[parent]["children"] = {}
+                self.modules[parent]["children"][module] = True
         else:
             service = stamp["module"]
 


### PR DESCRIPTION
This is a preliminary implementation.

In python services, sometimes we have code like:

```
import tangelo
tangelo.paths(".")
import cleverutils
```

If cleverutils changes, it won't be reimported.  If this is rewritten as

```
import tangelo
tangelo.import_local('cleverutils')
```

then cleverutils will be reimported if changed.

This is less obvious what it does (import is clearer than tangelo.import_local).  On the other hand, since you had to add '.' to the path anyway, I don't think it is more cryptic.

One limitation is that if you change cleverutils.py but not the module that imported it, currently neither will be reimported.  This should be fixed, as the primary point of this feature is to make tangelo responsive to changes in a python script.  This means that modules that call other modules need to have more complicated date checking in the ModuleCache class.

One coding aspect I don't like is that there is a module global in __init__ for the cache that is used for these imports.