### PR TITLE
Use travis containers.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: python
 
+sudo: false
+
 python:
     - 2.7
 
 script:
+    - pip install --upgrade pip
     - npm install -g grunt-cli
     - npm install
     - grunt

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -349,7 +349,7 @@ module.exports = function (grunt) {
 
         grunt.util.spawn({
             cmd: flake8,
-            args: this.filesSrc,
+            args: ["--config=setup.cfg"].concat(this.filesSrc),
             opts: {
                 stdio: "inherit"
             }
@@ -392,7 +392,7 @@ module.exports = function (grunt) {
         // version number, but setuptools will "normalize" it to
         // "foobar-0.8.1.dev0", so we need to do the same in order to install
         // the package created by the grunt package task.
-        pyversion = version.replace("-dev", ".dev0");
+        pyversion = version;
 
         grunt.util.spawn({
             cmd: pip,


### PR DESCRIPTION
In the grunt file, explicitly reference our flake8 config so it doesn't use the default of ~/.config/flake8.

Move to the latest version of pip.