### PR TITLE
Use travis containers.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 
+sudo: false
+
 python:
     - 2.7
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,7 +24,8 @@ module.exports = function (grunt) {
         pkgDataDir = "tangelo/tangelo/pkgdata/",
         pluginDir = pkgDataDir + "plugin/",
         webDir = pkgDataDir + "web/",
-        styleCheckFiles;
+        styleCheckFiles,
+        testingPort = "30047";
 
     tangeloCmdLine = function (hostname, port, root, cover) {
         var cmd,
@@ -167,7 +168,7 @@ module.exports = function (grunt) {
       blanket_qunit: {
           all: {
               options: {
-                  urls: ["http://127.0.0.1:30047/results/js/index.html?coverage=true&lights=4"],
+                  urls: ["http://127.0.0.1:" + testingPort + "/results/js/index.html?coverage=true&lights=4"],
                   threshold: 20,
                   verbose: true
               }
@@ -574,7 +575,7 @@ module.exports = function (grunt) {
         var done = this.async(),
             tangeloCmd;
 
-        tangeloCmd = tangeloCmdLine("127.0.0.1", "30047", "js/tests", false);
+        tangeloCmd = tangeloCmdLine("127.0.0.1", testingPort, "js/tests", false);
 
         grunt.util.spawn({
             cmd: tangeloCmd.cmd,
@@ -610,7 +611,7 @@ module.exports = function (grunt) {
 
                 done = this.async();
 
-                cmdline = tangeloCmdLine("127.0.0.1", "30047", "js/tests", !windows);
+                cmdline = tangeloCmdLine("127.0.0.1", testingPort, "js/tests", !windows);
 
                 console.log("Starting Tangelo server with: " + cmdline.cmd + " " + cmdline.args.join(" "));
                 process = grunt.util.spawn(cmdline, function () {});

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -167,7 +167,7 @@ module.exports = function (grunt) {
       blanket_qunit: {
           all: {
               options: {
-                  urls: ["http://localhost:50047/results/js/index.html?coverage=true&lights=4"],
+                  urls: ["http://127.0.0.1:30047/results/js/index.html?coverage=true&lights=4"],
                   threshold: 20,
                   verbose: true
               }
@@ -349,7 +349,7 @@ module.exports = function (grunt) {
 
         grunt.util.spawn({
             cmd: flake8,
-            args: this.filesSrc,
+            args: ["--config=setup.cfg"].concat(this.filesSrc),
             opts: {
                 stdio: "inherit"
             }
@@ -392,7 +392,10 @@ module.exports = function (grunt) {
         // version number, but setuptools will "normalize" it to
         // "foobar-0.8.1.dev0", so we need to do the same in order to install
         // the package created by the grunt package task.
-        pyversion = version.replace("-dev", ".dev0");
+        pyversion = version;
+        if (!grunt.file.exists("sdist/tangelo-" + pyversion + zipExt)) {
+            pyversion = version.replace("-dev", ".dev0");
+        }
 
         grunt.util.spawn({
             cmd: pip,
@@ -571,7 +574,7 @@ module.exports = function (grunt) {
         var done = this.async(),
             tangeloCmd;
 
-        tangeloCmd = tangeloCmdLine("localhost", "50047", "js/tests", false);
+        tangeloCmd = tangeloCmdLine("127.0.0.1", "30047", "js/tests", false);
 
         grunt.util.spawn({
             cmd: tangeloCmd.cmd,
@@ -607,7 +610,7 @@ module.exports = function (grunt) {
 
                 done = this.async();
 
-                cmdline = tangeloCmdLine("localhost", "50047", "js/tests", !windows);
+                cmdline = tangeloCmdLine("127.0.0.1", "30047", "js/tests", !windows);
 
                 console.log("Starting Tangelo server with: " + cmdline.cmd + " " + cmdline.args.join(" "));
                 process = grunt.util.spawn(cmdline, function () {});

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -388,11 +388,13 @@ module.exports = function (grunt) {
 
         done = this.async();
 
-        // This is necessary to reconcile Python setuptools's notion of version
-        // numbers with npm's.  Both accept "foobar-0.8.1-dev" as a valid
-        // version number, but setuptools will "normalize" it to
+        // This is sometimes necessary to reconcile Python setuptools's notion
+        // of version numbers with npm's.  Both accept "foobar-0.8.1-dev" as a
+        // valid version number, but setuptools will "normalize" it to
         // "foobar-0.8.1.dev0", so we need to do the same in order to install
-        // the package created by the grunt package task.
+        // the package created by the grunt package task.  Some versions of
+        // setuptools don't perform this normalization, so we check whether the
+        // file exists before doing the name conversion.
         pyversion = version;
         if (!grunt.file.exists("sdist/tangelo-" + pyversion + zipExt)) {
             pyversion = version.replace("-dev", ".dev0");


### PR DESCRIPTION
In the grunt file, explicitly reference our flake8 config so it doesn't use the default of ~/.config/flake8.

Try to make both travis and my local environment happy by searching for which file exists.

Use 127.0.0.1 instead of localhost.  This is needed for the travis container environment.