### PR TITLE
Import from source directory if in service area.

### DIFF
--- a/tangelo/tangelo/__init__.py
+++ b/tangelo/tangelo/__init__.py
@@ -1,12 +1,16 @@
+import __builtin__
 import cherrypy
 import copy
 import functools
+import imp
 import inspect
 import os.path
 import sys
 from types import StringTypes
 
 import tangelo.util
+
+builtin_import = __builtin__.__import__
 
 
 def content_type(t=None):
@@ -115,7 +119,7 @@ def paths(runtimepaths):
         runtimepaths = [runtimepaths]
 
     home = os.path.expanduser("~").split(os.path.sep)[:-1]
-    root = cherrypy.config.get("webroot")
+    root = os.path.abspath(cherrypy.config.get("webroot"))
 
     # This function returns an absolute path if the path is allowed (i.e., in
     # someone's tangelo_html directory, or under the web root directory), or
@@ -126,9 +130,8 @@ def paths(runtimepaths):
             log("Illegal path (absolute): %s" % (orig), "SERVICE")
             return None
 
-        path = os.path.abspath(cherrypy.thread_data.modulepath + os.path.sep +
-                               path)
-        if len(path) >= len(root) and path[:len(root)] == root:
+        path = os.path.abspath(os.path.join(cherrypy.thread_data.modulepath, path))
+        if path == root or path.startswith(root + os.path.sep):
             return path
 
         comp = path.split(os.path.sep)
@@ -145,8 +148,13 @@ def paths(runtimepaths):
     # to Nones will have been logged).
     newpaths = filter(lambda x: x is not None, map(good, runtimepaths))
 
+    # Use the import lock to have some thread safety
+    imp.acquire_lock()
+    # Exclude paths we've already added to the system
+    newpaths = [path for path in newpaths if path not in sys.path]
     # Finally, augment the path list.
     sys.path = newpaths + sys.path
+    imp.release_lock()
 
 
 def config():
@@ -267,3 +275,41 @@ def return_type(rettype):
 
         return converter
     return wrap
+
+
+def tangelo_import(*args, **kwargs):
+    """
+    When we are asked to import a module, if we get an import error and the
+    calling script is one we are serving (not one in the python libraries), try
+    again in the same directory as the script that is calling import.
+        It seems like we should use sys.meta_path and combine our path with the
+    path sent to imp.find_module.  This requires duplicating a bunch of logic
+    from the imp module and is actually heavier than this technique.
+
+    :params: see __builtin__.__import__
+    """
+    try:
+        return builtin_import(*args, **kwargs)
+    except ImportError:
+        path = os.path.abspath(cherrypy.thread_data.modulepath)
+        root = os.path.abspath(cherrypy.config.get("webroot"))
+        result = None
+        imp.acquire_lock()
+        oldpath = sys.path
+        try:
+            # If the module's path isn't in the system path but is in our
+            # serving area, temporarily add it and try the import again.
+            if path not in sys.path and (path == root or path.startswith(root + os.path.sep)):
+                sys.path = [path] + sys.path
+                result = builtin_import(*args, **kwargs)
+        finally:
+            sys.path = oldpath
+            imp.release_lock()
+        if result is not None:
+            return result
+        raise
+    # Any other exception will be raised, so we don't try to return anything.
+
+
+# Direct imports through our own function
+__builtin__.__import__ = tangelo_import

--- a/tests/service-import.py
+++ b/tests/service-import.py
@@ -1,0 +1,20 @@
+import nose
+import requests
+
+import fixture
+
+
+@nose.with_setup(fixture.start_tangelo, fixture.stop_tangelo)
+def test_service_import_local():
+    response = requests.get(fixture.url("import", "oct", "30", color="green", answer="42"))
+    expected = "\n".join(["[oct, 30]", "color -> green", "answer -> 42"])
+
+    assert response.content == expected
+
+
+@nose.with_setup(fixture.start_tangelo, fixture.stop_tangelo)
+def test_service_import_path():
+    response = requests.get(fixture.url("sub/importpath", "oct", "30", color="green", answer="42"))
+    expected = "\n".join(["[oct, 30]", "color -> green", "answer -> 42"])
+
+    assert response.content == expected

--- a/tests/web/import.py
+++ b/tests/web/import.py
@@ -1,0 +1,6 @@
+# This service imports a local script and rusn that
+import echo
+
+
+def run(*args, **kwargs):
+    return echo.run(*args, **kwargs)

--- a/tests/web/import.py
+++ b/tests/web/import.py
@@ -1,4 +1,4 @@
-# This service imports a local script and rusn that
+# This service imports a local script and runs that
 import echo
 
 

--- a/tests/web/sub/importpath.py
+++ b/tests/web/sub/importpath.py
@@ -1,4 +1,4 @@
-# This service imports a non-local script and rusn that
+# This service imports a non-local script and runs that
 import tangelo
 
 tangelo.paths('..')

--- a/tests/web/sub/importpath.py
+++ b/tests/web/sub/importpath.py
@@ -1,0 +1,9 @@
+# This service imports a non-local script and rusn that
+import tangelo
+
+tangelo.paths('..')
+import echo
+
+
+def run(*args, **kwargs):
+    return echo.run(*args, **kwargs)


### PR DESCRIPTION
If a service script tries to import and the import fails, it tries again within the same directory as the script.  Note that this means that built-in and installed libraries get precedence over user scripts with the same name.

This eliminates the need to ever call `tangelo.paths('.')`, but other paths can still be usefully added.

Add tests for importing locally and from tangelo.paths().

The paths computed in tangelo.paths are now more thread-safe and won't accrete if the same path is added multiple times.  There was a bug that if Tangelo were serving path foo/bar, then you could add a path foo/barbaz which wasn't in the served path.

This addresses issue #514.