### PR TITLE
Enable verbosity.

### DIFF
--- a/docs/tangelo-manpage.rst
+++ b/docs/tangelo-manpage.rst
@@ -4,7 +4,7 @@
 
 | tangelo [-h] [-c FILE] [-nc] [-a] [-na] [-p] [-np]
 |         [--hostname HOSTNAME] [--port PORT] [-u USERNAME]
-|         [-g GROUPNAME] [-r DIR] [--vtkpython FILE] [--verbose]
+|         [-g GROUPNAME] [-r DIR] [--vtkpython FILE] [--verbose] [--quiet]
 |         [--version] [--key FILE] [--cert FILE]
 
 Start a Tangelo server.
@@ -27,7 +27,8 @@ Optional argument                  Effect
 -g GROUPNAME, --group GROUPNAME    specifies the group to run as when root privileges are dropped
 -r DIR, --root DIR                 the directory from which Tangelo will serve content
 --examples                         serve the Tangelo example applications
---verbose, -v                      display extra information as Tangelo starts up
+--verbose, -v                      display extra information as Tangelo runs
+--quiet, -q                        reduce the amount of information displayed
 --version                          display Tangelo version number
 --key FILE                         the path to the SSL key. You must also specify --cert to serve content over https.
 --cert FILE                        the path to the SSL certificate. You must also specify --key to serve content over https.

--- a/docs/tangelo-py.rst
+++ b/docs/tangelo-py.rst
@@ -11,7 +11,7 @@ formatting errors; and web service utilities to supercharge Python services.
 Core Services
 =============
 
-.. py:function:: tangelo.log([context, ]msg)
+.. py:function:: tangelo.log([context, ]msg[, lvl=(logging level)])
 
     Writes a message ``msg`` to the log file.  The optional ``context`` is a
     descriptive tag that will be prepended to the message within the log file
@@ -19,7 +19,8 @@ Core Services
     in Tangelo include "TANGELO" (to describe startup/shutdown activities), and
     "ENGINE" (which describes actions being taken by CherryPy).  This function
     may be useful for debugging or otherwise tracking a service's activities as
-    it runs.
+    it runs.  The optional logging level ``lvl`` is one of the python logging
+    constants.  By default, ``logging.INFO`` is used.
 
 .. py:function:: tangelo.log_info([context, ]msg)
 
@@ -31,25 +32,33 @@ Core Services
 
 .. py:function:: tangelo.log_warning([context, ]msg)
 
-    Variant of :py:func:`tangelo.log` that writes out messages in yellow.
-    Warnings are messages indicating that something did not work out as
-    expected, but not so bad as to compromise the continued running of the
-    system.  For example, if Tangelo is unable to load a plugin for any reason,
-    Tangelo itself is able to continue running - this constitutes a warning
-    about the failed plugin loading.
+    Variant of :py:func:`tangelo.log` that writes out messages in yellow at
+    level ``logging.WARNING``.  Warnings are messages indicating that something
+    did not work out as expected, but not so bad as to compromise the continued
+    running of the system.  For example, if Tangelo is unable to load a plugin
+    for any reason, Tangelo itself is able to continue running - this
+    constitutes a warning about the failed plugin loading.
 
 .. py:function:: tangelo.log_error([context, ]msg)
 
-    Variant of :py:func:`tangelo.log` that writes out messages in red.  Errors
-    describe conditions that prevent the further functioning of the system.
-    Generally, you will not need to call this function.
+    Variant of :py:func:`tangelo.log` that writes out messages in red at level
+    ``logging.ERROR``.  Errors describe conditions that prevent the further 
+    functioning of the system.  Generally, you will not need to call this
+    function.
 
 .. py:function:: tangelo.log_success([context, ]msg)
 
     Variant of :py:func:`tangelo.log` that writes out messages in green.  This
-    is meant to declare that some operation went as expected.  It is generally
-    not needed because the absence of errors and warnings can generally be
-    regarded as a success condition.
+    is meant to declare that some operation went as expected, and is written at
+    level ``logging.WARNING`` as it is considered more important than general
+    information.  It is generally not needed because the absence of errors and
+    warnings can generally be regarded as a success condition.
+
+.. py:function:: tangelo.log_debug([context, ]msg)
+
+    Variant of :py:func:`tangelo.log` that writes out messages at level
+    ``logging.DEBUG``.  These messages are hidden by default (increase the
+    verbosity to see them).
 
 HTTP Interaction
 ================

--- a/docs/tangelo-py.rst
+++ b/docs/tangelo-py.rst
@@ -46,14 +46,6 @@ Core Services
     functioning of the system.  Generally, you will not need to call this
     function.
 
-.. py:function:: tangelo.log_success([context, ]msg)
-
-    Variant of :py:func:`tangelo.log` that writes out messages in green.  This
-    is meant to declare that some operation went as expected, and is written at
-    level ``logging.WARNING`` as it is considered more important than general
-    information.  It is generally not needed because the absence of errors and
-    warnings can generally be regarded as a success condition.
-
 .. py:function:: tangelo.log_debug([context, ]msg)
 
     Variant of :py:func:`tangelo.log` that writes out messages at level

--- a/docs/tangelo-py.rst
+++ b/docs/tangelo-py.rst
@@ -11,9 +11,9 @@ formatting errors; and web service utilities to supercharge Python services.
 Core Services
 =============
 
-.. py:function:: tangelo.log([context, ]msg[, lvl=(logging level)])
+.. py:function:: tangelo.log([context, ]msg[, lvl=loglevel])
 
-    Writes a message ``msg`` to the log file.  The optional ``context`` is a
+    Writes a message `msg` to the log file.  The optional `context` is a
     descriptive tag that will be prepended to the message within the log file
     (defaulting to "TANGELO" if omitted).  Common context tags used internally
     in Tangelo include "TANGELO" (to describe startup/shutdown activities), and
@@ -22,35 +22,49 @@ Core Services
     it runs.  The optional logging level ``lvl`` is one of the python logging
     constants.  By default, ``logging.INFO`` is used.
 
+    Generally you should use one of the variants of this function listed below,
+    but if you want to write a logging message in the terminal's default color,
+    you can use this function, specifying the log level you need.
+
+.. py:function:: tangelo.log_debug([context, ]msg)
+
+    Variant of :py:func:`tangelo.log` that writes out messages in blue, at level
+    ``logging.DEBUG``.  These messages can be used to diagnose, e.g., plugins or
+    services in development.  By default, these messages are hidden - you can
+    increase the verbosity to see them.
+
 .. py:function:: tangelo.log_info([context, ]msg)
 
-    Variant of :py:func:`tangelo.log` that writes out messages in purple.
-    Informational messages are those that simply declare a helpful description
-    of what the system is doing at the moment.  For example, when a plugin is
-    about to perform initialization, a call like ``tangelo.log_info("FOOBAR",
-    "About to initialize...")`` may be appropriate.
+    Variant of :py:func:`tangelo.log` that writes out messages in purple at
+    level ``logging.INFO``.  Informational messages describe what the system is
+    doing at the moment.  For example, when a plugin is about to perform
+    initialization, a call like ``tangelo.log_info("FOOBAR", "About to
+    initialize...")`` may be appropriate.
 
 .. py:function:: tangelo.log_warning([context, ]msg)
 
     Variant of :py:func:`tangelo.log` that writes out messages in yellow at
     level ``logging.WARNING``.  Warnings are messages indicating that something
-    did not work out as expected, but not so bad as to compromise the continued
-    running of the system.  For example, if Tangelo is unable to load a plugin
-    for any reason, Tangelo itself is able to continue running - this
-    constitutes a warning about the failed plugin loading.
+    did not work out as expected, but the requested action will still be
+    accomplished (perhaps differently than was expected by the user).  For
+    example, if a plugin needs to fall back on a default method for doing
+    something because the requested method was not available, this might be
+    reported by a warning message.
 
 .. py:function:: tangelo.log_error([context, ]msg)
 
     Variant of :py:func:`tangelo.log` that writes out messages in red at level
-    ``logging.ERROR``.  Errors describe conditions that prevent the further 
-    functioning of the system.  Generally, you will not need to call this
-    function.
+    ``logging.ERROR``.  Errors describe instances when Tangelo or a plugin fails
+    to perform a requested task, without compromising Tangelo's ability to
+    continue running.  For example, if a plugin requires a file that is missing,
+    it might report an error condition using this function.
 
-.. py:function:: tangelo.log_debug([context, ]msg)
+.. py:function:: tangelo.log_critical([context, ]msg)
 
-    Variant of :py:func:`tangelo.log` that writes out messages at level
-    ``logging.DEBUG``.  These messages are hidden by default (increase the
-    verbosity to see them).
+    Variant of :py:func:`tangelo.log` that writes out messages in bright, bold
+    red at level ``logging.CRITICAL``.  Critical errors describe conditions that
+    immediately prevent the further functioning of the system, generally leading
+    to Tangelo halting.  Generally, you will not need to call this function.
 
 HTTP Interaction
 ================

--- a/tangelo/tangelo/__init__.py
+++ b/tangelo/tangelo/__init__.py
@@ -57,6 +57,10 @@ def log(section, message=None, color=None, lvl=logging.INFO):
     cherrypy.log.error(str(message), section, lvl)
 
 
+def log_critical(section, message=None):
+    log(section, message, color="\033[1;91m", lvl=logging.CRITICAL)
+
+
 def log_error(section, message=None):
     log(section, message, color="\033[1;91m", lvl=logging.ERROR)
 

--- a/tangelo/tangelo/__init__.py
+++ b/tangelo/tangelo/__init__.py
@@ -62,11 +62,11 @@ def log_critical(section, message=None):
 
 
 def log_error(section, message=None):
-    log(section, message, color="\033[1;91m", lvl=logging.ERROR)
+    log(section, message, color="\033[31m", lvl=logging.ERROR)
 
 
 def log_warning(section, message=None):
-    log(section, message, color="\033[1;33m", lvl=logging.WARNING)
+    log(section, message, color="\033[33m", lvl=logging.WARNING)
 
 
 def log_info(section, message=None):
@@ -74,7 +74,7 @@ def log_info(section, message=None):
 
 
 def log_debug(section, message=None):
-    log(section, message, lvl=logging.DEBUG)
+    log(section, message, color="\033[1;34m", lvl=logging.DEBUG)
 
 
 def request_path():

--- a/tangelo/tangelo/__init__.py
+++ b/tangelo/tangelo/__init__.py
@@ -49,11 +49,11 @@ def log(section, message=None, color=None, lvl=logging.INFO):
         section = "%s%s" % (color, section)
         message = "%s%s" % (message, "\033[0m")
 
-    # There is a suble difference between cherrypy.log and cherrypy.log.error,
-    # even though one just calls the other via a __call__ method.  For reasons
-    # I don't understand, the cherrypy.log message seems to have an extra
-    # limit to log levels of logging.INFO, whereas cherrypy.log.error honors
-    # the log level that can be set.
+    # There is a subtle difference between cherrypy.log and cherrypy.log.error,
+    # even though one just calls the other via a __call__ method.  For reasons I
+    # don't understand, the cherrypy.log message seems to have an extra limit to
+    # log levels of logging.INFO, whereas cherrypy.log.error honors the log
+    # level that can be set.
     cherrypy.log.error(str(message), section, lvl)
 
 

--- a/tangelo/tangelo/__init__.py
+++ b/tangelo/tangelo/__init__.py
@@ -296,6 +296,8 @@ def tangelo_import(*args, **kwargs):
     try:
         return builtin_import(*args, **kwargs)
     except ImportError:
+        if not hasattr(cherrypy.thread_data, "modulepath"):
+            raise
         path = os.path.abspath(cherrypy.thread_data.modulepath)
         root = os.path.abspath(cherrypy.config.get("webroot"))
         result = None

--- a/tangelo/tangelo/__init__.py
+++ b/tangelo/tangelo/__init__.py
@@ -61,10 +61,6 @@ def log_error(section, message=None):
     log(section, message, color="\033[1;91m", lvl=logging.ERROR)
 
 
-def log_success(section, message=None):
-    log(section, message, color="\033[32m", lvl=logging.WARNING)
-
-
 def log_warning(section, message=None):
     log(section, message, color="\033[1;33m", lvl=logging.WARNING)
 

--- a/tangelo/tangelo/__init__.py
+++ b/tangelo/tangelo/__init__.py
@@ -49,7 +49,12 @@ def log(section, message=None, color=None, lvl=logging.INFO):
         section = "%s%s" % (color, section)
         message = "%s%s" % (message, "\033[0m")
 
-    cherrypy.log(str(message), section, lvl)
+    # There is a suble difference between cherrypy.log and cherrypy.log.error,
+    # even though one just calls the other via a __call__ method.  For reasons
+    # I don't understand, the cherrypy.log message seems to have an extra
+    # limit to log levels of logging.INFO, whereas cherrypy.log.error honors
+    # the log level that can be set.
+    cherrypy.log.error(str(message), section, lvl)
 
 
 def log_error(section, message=None):

--- a/tangelo/tangelo/__init__.py
+++ b/tangelo/tangelo/__init__.py
@@ -5,6 +5,7 @@ import functools
 import imp
 import inspect
 import os.path
+import logging
 import sys
 from types import StringTypes
 
@@ -39,7 +40,7 @@ def http_status(code, message=None):
     cherrypy.response.status = "%s%s" % (code, " %s" % (message) if message is not None else "")
 
 
-def log(section, message=None, color=None):
+def log(section, message=None, color=None, lvl=logging.INFO):
     if message is None:
         message = section
         section = "TANGELO"
@@ -48,23 +49,27 @@ def log(section, message=None, color=None):
         section = "%s%s" % (color, section)
         message = "%s%s" % (message, "\033[0m")
 
-    cherrypy.log(str(message), section)
+    cherrypy.log(str(message), section, lvl)
 
 
 def log_error(section, message=None):
-    log(section, message, color="\033[1;91m")
+    log(section, message, color="\033[1;91m", lvl=logging.ERROR)
 
 
 def log_success(section, message=None):
-    log(section, message, color="\033[32m")
+    log(section, message, color="\033[32m", lvl=logging.WARNING)
 
 
 def log_warning(section, message=None):
-    log(section, message, color="\033[1;33m")
+    log(section, message, color="\033[1;33m", lvl=logging.WARNING)
 
 
 def log_info(section, message=None):
-    log(section, message, color="\033[35m")
+    log(section, message, color="\033[35m", lvl=logging.INFO)
+
+
+def log_debug(section, message=None):
+    log(section, message, lvl=logging.DEBUG)
 
 
 def request_path():

--- a/tangelo/tangelo/__main__.py
+++ b/tangelo/tangelo/__main__.py
@@ -3,6 +3,7 @@
 import argparse
 import os
 import cherrypy
+import logging
 import platform
 import signal
 import sys
@@ -212,7 +213,8 @@ def main():
     p.add_argument("-u", "--user", type=str, default=None, metavar="USERNAME", help="specifies the user to run as when root privileges are dropped")
     p.add_argument("-g", "--group", type=str, default=None, metavar="GROUPNAME", help="specifies the group to run as when root privileges are dropped")
     p.add_argument("-r", "--root", type=str, default=None, metavar="DIR", help="the directory from which Tangelo will serve content")
-    p.add_argument("--verbose", "-v", action="store_true", help="display extra information as Tangelo starts up")
+    p.add_argument("--verbose", "-v", action="append_const", help="display extra information as Tangelo runs", default=[logging.INFO], const=logging.DEBUG - logging.INFO)
+    p.add_argument("--quiet", "-q", action="append_const", help="reduce the amount of information displayed", dest="verbose", const=logging.INFO - logging.DEBUG)
     p.add_argument("--version", action="store_true", help="display Tangelo version number")
     p.add_argument("--key", type=str, default=None, metavar="FILE", help="the path to the SSL key.  You must also specify --cert to serve content over https.")
     p.add_argument("--cert", type=str, default=None, metavar="FILE", help="the path to the SSL certificate.  You must also specify --key to serve content over https.")
@@ -223,6 +225,9 @@ def main():
     if args.version:
         print tangelo_version
         return 0
+
+    # Set the verbosity
+    cherrypy.log.error_log.setLevel(sum(args.verbose))
 
     # Make sure user didn't specify conflicting flags.
     if args.access_auth and args.no_access_auth:

--- a/tangelo/tangelo/__main__.py
+++ b/tangelo/tangelo/__main__.py
@@ -256,7 +256,7 @@ def main():
 
     if args.no_show_py and args.show_py:
         tangelo.log_critical("ERROR", "can't specify both --show-py and --no-show-py together")
-        sys.exit(1)
+        return 1
 
     # Decide if we have a configuration file or not.
     cfg_file = args.config

--- a/tangelo/tangelo/__main__.py
+++ b/tangelo/tangelo/__main__.py
@@ -153,7 +153,7 @@ def polite(signum, frame):
 
 
 def die(signum, frame):
-    tangelo.log_error("TANGELO", "Received quit signal.  Exiting immediately.")
+    tangelo.log_critical("TANGELO", "Received quit signal.  Exiting immediately.")
     os.kill(os.getpid(), signal.SIGKILL)
 
 
@@ -231,31 +231,31 @@ def main():
 
     # Make sure user didn't specify conflicting flags.
     if args.access_auth and args.no_access_auth:
-        tangelo.log_error("ERROR", "can't specify both --access-auth (-a) and --no-access-auth (-na) together")
+        tangelo.log_critical("ERROR", "can't specify both --access-auth (-a) and --no-access-auth (-na) together")
         return 1
 
     if args.drop_privileges and args.no_drop_privileges:
-        tangelo.log_error("ERROR", "can't specify both --drop-privileges (-p) and --no-drop-privileges (-np) together")
+        tangelo.log_critical("ERROR", "can't specify both --drop-privileges (-p) and --no-drop-privileges (-np) together")
         return 1
 
     if args.no_sessions and args.sessions:
-        tangelo.log_error("ERROR", "can't specify both --sessions (-s) and --no-sessions (-ns) together")
+        tangelo.log_critical("ERROR", "can't specify both --sessions (-s) and --no-sessions (-ns) together")
         return 1
 
     if args.examples and args.root:
-        tangelo.log_error("ERROR", "can't specify both --examples and --root (-r) together")
+        tangelo.log_critical("ERROR", "can't specify both --examples and --root (-r) together")
         return 1
 
     if args.examples and args.config:
-        tangelo.log_error("ERROR", "can't specify both --examples and --config (-c) together")
+        tangelo.log_critical("ERROR", "can't specify both --examples and --config (-c) together")
         return 1
 
     if args.no_list_dir and args.list_dir:
-        tangelo.log_error("ERROR", "can't specify both --list-dir and --no-list-dir together")
-        sys.exit(1)
+        tangelo.log_critical("ERROR", "can't specify both --list-dir and --no-list-dir together")
+        return 1
 
     if args.no_show_py and args.show_py:
-        tangelo.log_error("ERROR", "can't specify both --show-py and --no-show-py together")
+        tangelo.log_critical("ERROR", "can't specify both --show-py and --no-show-py together")
         sys.exit(1)
 
     # Decide if we have a configuration file or not.
@@ -270,13 +270,13 @@ def main():
     try:
         config = Config(cfg_file)
     except (IOError, ValueError) as e:
-        tangelo.log_error("ERROR", e)
+        tangelo.log_critical("ERROR", e)
         return 1
 
     # Type check the config entries.
     if not config.type_check():
         for message in config.errors:
-            tangelo.log_error("TANGELO", message)
+            tangelo.log_critical("TANGELO", message)
         return 1
 
     # Determine whether to use access auth.
@@ -369,7 +369,7 @@ def main():
         tangelo.log("TANGELO", "\tSSL Cert file: %s" % (ssl_cert))
         tangelo.log("TANGELO", "\tSSL Key file: %s" % (ssl_key))
     elif not (ssl_key is None and ssl_cert is None):
-        tangelo.log_error("TANGELO", "error: SSL key or SSL cert missing")
+        tangelo.log_critical("TANGELO", "error: SSL key or SSL cert missing")
         return 1
     else:
         tangelo.log("TANGELO", "HTTPS disabled")
@@ -385,7 +385,7 @@ def main():
         root = get_web_directory()
         tangelo.log_info("TANGELO", "Looking for example web content path in %s" % (root))
         if not os.path.exists(root):
-            tangelo.log_error("ERROR", "could not find examples package")
+            tangelo.log_critical("ERROR", "could not find examples package")
             return 1
 
         # Set the examples plugins.
@@ -422,7 +422,7 @@ def main():
     # Check for any errors - if there are, report them and exit.
     if not plugins.good():
         for message in plugins.errors:
-            tangelo.log_error("PLUGIN", message)
+            tangelo.log_critical("PLUGIN", message)
         return 1
 
     # Save the plugin manager for use later (when unloading plugins during
@@ -492,7 +492,7 @@ def main():
                 value = group
                 gid = to_signed(grp.getgrnam(group).gr_gid)
             except KeyError:
-                tangelo.log_error("TANGELO", "no such %s '%s' to drop privileges to" % (mode, value))
+                tangelo.log_critical("TANGELO", "no such %s '%s' to drop privileges to" % (mode, value))
                 return 1
 
             # Set the process home directory to be the dropped-down user's.

--- a/tangelo/tangelo/__main__.py
+++ b/tangelo/tangelo/__main__.py
@@ -259,6 +259,22 @@ def main():
         tangelo.log_critical("ERROR", "can't specify both --show-py and --no-show-py together")
         return 1
 
+    # Report the logging level.
+    if log_level > logging.CRITICAL:
+        log_level_tag = "NONE"
+    elif log_level > logging.ERROR:
+        log_level_tag = "CRITICAL"
+    elif log_level > logging.WARNING:
+        log_level_tag = "ERROR"
+    elif log_level > logging.INFO:
+        log_level_tag = "WARNING"
+    elif log_level > logging.DEBUG:
+        log_level_tag = "INFO"
+    else:
+        log_level_tag = "DEBUG"
+
+    tangelo.log_info("TANGELO", "Logging level: %s (%d)" % (log_level_tag, log_level))
+
     # Decide if we have a configuration file or not.
     cfg_file = args.config
     if cfg_file is None:

--- a/tangelo/tangelo/__main__.py
+++ b/tangelo/tangelo/__main__.py
@@ -261,10 +261,10 @@ def main():
     # Decide if we have a configuration file or not.
     cfg_file = args.config
     if cfg_file is None:
-        tangelo.log("TANGELO", "No configuration file specified - using command line args and defaults")
+        tangelo.log_info("TANGELO", "No configuration file specified - using command line args and defaults")
     else:
         cfg_file = tangelo.util.expandpath(cfg_file)
-        tangelo.log("TANGELO", "Using configuration file %s" % (cfg_file))
+        tangelo.log_info("TANGELO", "Using configuration file %s" % (cfg_file))
 
     # Parse the config file; report errors if any.
     try:
@@ -287,7 +287,7 @@ def main():
     else:
         access_auth = (args.access_auth is not None) or (not args.no_access_auth)
 
-    tangelo.log("TANGELO", "Access authentication %s" % ("enabled" if access_auth else "disabled"))
+    tangelo.log_info("TANGELO", "Access authentication %s" % ("enabled" if access_auth else "disabled"))
 
     # Determine whether to perform privilege drop.
     drop_privileges = True
@@ -305,7 +305,7 @@ def main():
     else:
         sessions = (args.sessions is not None) or (not args.no_sessions)
 
-    tangelo.log("TANGELO", "Sessions %s" % ("enabled" if sessions else "disabled"))
+    tangelo.log_info("TANGELO", "Sessions %s" % ("enabled" if sessions else "disabled"))
 
     # Determine whether to serve directory listings by default.
     listdir = False
@@ -316,7 +316,7 @@ def main():
         listdir = (args.list_dir is not None) or (not args.no_list_dir)
 
     cherrypy.config["listdir"] = listdir
-    tangelo.log("TANGELO", "Directory content serving %s" % ("enabled" if listdir else "disabled"))
+    tangelo.log_info("TANGELO", "Directory content serving %s" % ("enabled" if listdir else "disabled"))
 
     # Determine whether to serve web service Python source code by default.
     showpy = False
@@ -327,7 +327,7 @@ def main():
         showpy = (args.show_py is not None) or (not args.no_show_py)
 
     cherrypy.config["showpy"] = showpy
-    tangelo.log("TANGELO", "Web service source code serving %s" % ("enabled" if showpy else "disabled"))
+    tangelo.log_info("TANGELO", "Web service source code serving %s" % ("enabled" if showpy else "disabled"))
 
     # Extract the rest of the arguments, giving priority first to command line
     # arguments, then to the configuration file (if any), and finally to a
@@ -337,13 +337,13 @@ def main():
     user = args.user or config.user or "nobody"
     group = args.group or config.group or "nobody"
 
-    tangelo.log("TANGELO", "Hostname: %s" % (hostname))
-    tangelo.log("TANGELO", "Port: %d" % (port))
+    tangelo.log_info("TANGELO", "Hostname: %s" % (hostname))
+    tangelo.log_info("TANGELO", "Port: %d" % (port))
 
-    tangelo.log("TANGELO", "Privilege drop %s" % ("enabled (if necessary)" if drop_privileges else "disabled"))
+    tangelo.log_info("TANGELO", "Privilege drop %s" % ("enabled (if necessary)" if drop_privileges else "disabled"))
     if drop_privileges:
-        tangelo.log("TANGELO", "\tUser: %s" % (user))
-        tangelo.log("TANGELO", "\tGroup: %s" % (group))
+        tangelo.log_info("TANGELO", "\tUser: %s" % (user))
+        tangelo.log_info("TANGELO", "\tGroup: %s" % (group))
 
     # HTTPS support
     #
@@ -365,14 +365,14 @@ def main():
         cherrypy.config.update({"server.ssl_module": "pyopenssl",
                                 "server.ssl_certificate": ssl_cert,
                                 "server.ssl_private_key": ssl_key})
-        tangelo.log("TANGELO", "HTTPS enabled")
-        tangelo.log("TANGELO", "\tSSL Cert file: %s" % (ssl_cert))
-        tangelo.log("TANGELO", "\tSSL Key file: %s" % (ssl_key))
+        tangelo.log_info("TANGELO", "HTTPS enabled")
+        tangelo.log_info("TANGELO", "\tSSL Cert file: %s" % (ssl_cert))
+        tangelo.log_info("TANGELO", "\tSSL Key file: %s" % (ssl_key))
     elif not (ssl_key is None and ssl_cert is None):
         tangelo.log_critical("TANGELO", "error: SSL key or SSL cert missing")
         return 1
     else:
-        tangelo.log("TANGELO", "HTTPS disabled")
+        tangelo.log_info("TANGELO", "HTTPS disabled")
 
     # We need a web root - use the installed example web directory as a
     # fallback.  This might be found in a few different places, so try them one
@@ -401,7 +401,7 @@ def main():
     else:
         root = tangelo.util.expandpath(".")
 
-    tangelo.log("TANGELO", "Serving content from %s" % (root))
+    tangelo.log_info("TANGELO", "Serving content from %s" % (root))
 
     # Set the web root directory.
     cherrypy.config.update({"webroot": root})
@@ -455,10 +455,10 @@ def main():
         # If we're on windows, don't supply any username/groupname, and just
         # assume we should drop priveleges.
         if platform.system() == "Windows":
-            tangelo.log("TANGELO", "Performing privilege drop")
+            tangelo.log_info("TANGELO", "Performing privilege drop")
             cherrypy.process.plugins.DropPrivileges(cherrypy.engine).subscribe()
         elif os.getuid() == 0:
-            tangelo.log("TANGELO", "Performing privilege drop")
+            tangelo.log_info("TANGELO", "Performing privilege drop")
 
             # Reaching here means we're on unix, and we are the root user, so go
             # ahead and drop privileges to the requested user/group.
@@ -501,7 +501,7 @@ def main():
             # Perform the actual UID/GID change.
             cherrypy.process.plugins.DropPrivileges(cherrypy.engine, uid=uid, gid=gid).subscribe()
         else:
-            tangelo.log("TANGELO", "Not performing privilege drop (because not running as superuser)")
+            tangelo.log_info("TANGELO", "Not performing privilege drop (because not running as superuser)")
 
     # Set up websocket handling.  Use the pass-through subclassed version of the
     # plugin so we can set a priority on it that doesn't conflict with privilege

--- a/tangelo/tangelo/__main__.py
+++ b/tangelo/tangelo/__main__.py
@@ -227,7 +227,8 @@ def main():
         return 0
 
     # Set the verbosity
-    cherrypy.log.error_log.setLevel(sum(args.verbose))
+    log_level = max(sum(args.verbose), 1)
+    cherrypy.log.error_log.setLevel(log_level)
 
     # Make sure user didn't specify conflicting flags.
     if args.access_auth and args.no_access_auth:

--- a/tangelo/tangelo/__main__.py
+++ b/tangelo/tangelo/__main__.py
@@ -176,7 +176,7 @@ def shutdown(signum, frame):
     cherrypy.engine.stop()
     cherrypy.engine.exit()
 
-    tangelo.log_success("TANGELO", "Be seeing you.")
+    tangelo.log_info("\033[32mTANGELO", "\033[32mBe seeing you.")
 
 
 def get_pkgdata_dir():
@@ -524,7 +524,7 @@ def main():
 
     # Start the CherryPy engine.
     cherrypy.engine.start()
-    tangelo.log_success("TANGELO", "Server is running")
+    tangelo.log_info("\033[32mTANGELO", "\033[32mServer is running")
     cherrypy.engine.block()
 
 if __name__ == "__main__":

--- a/tangelo/tangelo/pkgdata/plugin/vtkweb/web/vtkweb.py
+++ b/tangelo/tangelo/pkgdata/plugin/vtkweb/web/vtkweb.py
@@ -256,7 +256,7 @@ def delete(key=None):
     proc = processes[key]
     proc["process"].terminate()
     proc["process"].wait()
-    tangelo.log_success("VTKWEB", "Process terminated")
+    tangelo.log_info("VTKWEB", "Process terminated")
 
     # Remove the process entry from the table.
     del processes[key]

--- a/tangelo/tangelo/server.py
+++ b/tangelo/tangelo/server.py
@@ -653,7 +653,7 @@ class Plugins(object):
                 self.errors.append("Plugin %s failed to load" % (plugin))
                 return
 
-            tangelo.log_success("Plugin %s loaded" % (plugin))
+            tangelo.log_info("Plugin %s loaded" % (plugin))
 
     def good(self):
         return len(self.errors) == 0
@@ -779,7 +779,7 @@ class Plugins(object):
                 tangelo.log_warning("PLUGIN", "Could not run teardown:\n%s", (traceback.format_exc()))
 
         del self.plugins[plugin_name]
-        tangelo.log_success("plugin %s unloaded" % (plugin_name))
+        tangelo.log_info("plugin %s unloaded" % (plugin_name))
 
     def unload_all(self):
         for plugin_name in self.plugins.keys():

--- a/tests/fixture/__init__.py
+++ b/tests/fixture/__init__.py
@@ -83,8 +83,10 @@ def start_tangelo(*args, **kwargs):
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE)
 
+    start = time.time()
     buf = []
     return_stderr = kwargs.get("stderr", False)
+    timeout = kwargs.get("timeout", 5)
     while True:
         line = process.stderr.readline()
         buf.append(line)
@@ -94,6 +96,11 @@ def start_tangelo(*args, **kwargs):
         elif line.rstrip().endswith("ENGINE Bus EXITED") or process.poll() is not None:
             process = None
             raise RuntimeError("Could not start Tangelo:\n%s" % ("".join(buf)))
+        elif time.time() - start > timeout:
+            if process.poll() is None:
+                return buf if return_stderr else 0
+            else:
+                raise RuntimeError("Could not start Tangelo:\n%s" % ("".join(buf)))
 
 
 def stop_tangelo():

--- a/tests/fixture/__init__.py
+++ b/tests/fixture/__init__.py
@@ -79,14 +79,13 @@ def start_tangelo(*args, **kwargs):
         stderr=subprocess.PIPE)
 
     buf = []
+    return_stderr = kwargs.get("stderr", False)
     while True:
         line = process.stderr.readline()
         buf.append(line)
 
         if line.rstrip().endswith("Server is running\x1b[0m"):
-            if kwargs.get('stderr', False):
-                return buf
-            return 0
+            return buf if return_stderr else 0
         elif line.rstrip().endswith("ENGINE Bus EXITED") or process.poll() is not None:
             process = None
             raise RuntimeError("Could not start Tangelo:\n%s" % ("".join(buf)))

--- a/tests/fixture/__init__.py
+++ b/tests/fixture/__init__.py
@@ -28,6 +28,8 @@ def relative_path(path):
 
 def run_tangelo(*args, **kwargs):
     timeout = kwargs.get("timeout", 5)
+    terminate = kwargs.get("terminate", False)
+
     tangelo = ["venv/Scripts/python", "venv/Scripts/tangelo"] if windows() else ["venv/bin/tangelo"]
 
     # Start Tangelo with the specified arguments, and immediately poll the
@@ -41,6 +43,9 @@ def run_tangelo(*args, **kwargs):
         time.sleep(0.5)
         proc.poll()
         now = datetime.datetime.now()
+
+    if terminate:
+        proc.terminate()
 
     return (proc.returncode, filter(None, proc.stdout.read().splitlines()), filter(None, proc.stderr.read().splitlines()))
 

--- a/tests/fixture/__init__.py
+++ b/tests/fixture/__init__.py
@@ -83,7 +83,7 @@ def start_tangelo(*args, **kwargs):
         line = process.stderr.readline()
         buf.append(line)
 
-        if line.rstrip().endswith("TANGELO Server is running\x1b[0m"):
+        if line.rstrip().endswith("Server is running\x1b[0m"):
             if kwargs.get('stderr', False):
                 return buf
             return 0

--- a/tests/fixture/__init__.py
+++ b/tests/fixture/__init__.py
@@ -1,4 +1,3 @@
-import datetime
 import os
 import platform
 import subprocess
@@ -38,11 +37,10 @@ def run_tangelo(*args, **kwargs):
     proc.poll()
 
     # Run in a loop until the timeout expires or the process ends.
-    now = start = datetime.datetime.now()
-    while (now - start).total_seconds() < timeout and proc.returncode is None:
+    start = time.time()
+    while time.time() - start < timeout and proc.returncode is None:
         time.sleep(0.5)
         proc.poll()
-        now = datetime.datetime.now()
 
     if terminate:
         proc.terminate()

--- a/tests/tangelo-config.py
+++ b/tests/tangelo-config.py
@@ -6,11 +6,11 @@ def test_bad_config():
 
     signal = "ERROR while parsing"
 
-    print "Expected: '%s' in second line of log" % (signal)
+    print "Expected: '%s' in third line of log" % (signal)
     print "Received: %s" % (stderr[1] if len(stderr) > 1 else "")
 
     assert len(stderr) > 1
-    assert signal in stderr[1]
+    assert signal in stderr[2]
 
 
 def test_non_dict_config():
@@ -18,8 +18,8 @@ def test_non_dict_config():
 
     signal = "does not contain associative array"
 
-    print "Expected: '%s' in second line of log" % (signal)
+    print "Expected: '%s' in third line of log" % (signal)
     print "Received: %s" % (stderr[1] if len(stderr) > 1 else "")
 
     assert len(stderr) > 1
-    assert signal in stderr[1]
+    assert signal in stderr[2]

--- a/tests/tangelo-verbose.py
+++ b/tests/tangelo-verbose.py
@@ -5,15 +5,15 @@ def test_standard_verbosity():
     stderr = fixture.start_tangelo(stderr=True)
     stderr = '\n'.join(stderr)
 
+    fixture.stop_tangelo()
     assert 'TANGELO Server is running' in stderr
     assert 'TANGELO Hostname' in stderr
-    fixture.stop_tangelo()
 
 
 def test_lower_verbosity():
     stderr = fixture.start_tangelo("-q", stderr=True)
     stderr = '\n'.join(stderr)
 
+    fixture.stop_tangelo()
     assert 'TANGELO Server is running' in stderr
     assert 'TANGELO Hostname' not in stderr
-    fixture.stop_tangelo()

--- a/tests/tangelo-verbose.py
+++ b/tests/tangelo-verbose.py
@@ -10,9 +10,6 @@ def test_standard_verbosity():
 
 
 def test_lower_verbosity():
-    stderr = fixture.start_tangelo("-q", stderr=True)
-    stderr = '\n'.join(stderr)
+    (_, _, stderr) = fixture.run_tangelo("-q", "--port", "30047", timeout=3, terminate=True)
 
-    fixture.stop_tangelo()
-    assert 'TANGELO Server is running' in stderr
-    assert 'TANGELO Hostname' not in stderr
+    assert len(stderr) == 0

--- a/tests/tangelo-verbose.py
+++ b/tests/tangelo-verbose.py
@@ -5,8 +5,8 @@ def test_standard_verbosity():
     (_, _, stderr) = fixture.run_tangelo("--port", "30047", timeout=3, terminate=True)
     stderr = '\n'.join(stderr)
 
-    assert 'TANGELO Server is running' in stderr
-    assert 'TANGELO Hostname' in stderr
+    assert 'Server is running' in stderr
+    assert 'Hostname' in stderr
 
 
 def test_lower_verbosity():

--- a/tests/tangelo-verbose.py
+++ b/tests/tangelo-verbose.py
@@ -2,10 +2,9 @@ import fixture
 
 
 def test_standard_verbosity():
-    stderr = fixture.start_tangelo(stderr=True)
+    (_, _, stderr) = fixture.run_tangelo("--port", "30047", timeout=3, terminate=True)
     stderr = '\n'.join(stderr)
 
-    fixture.stop_tangelo()
     assert 'TANGELO Server is running' in stderr
     assert 'TANGELO Hostname' in stderr
 

--- a/tests/tangelo-verbose.py
+++ b/tests/tangelo-verbose.py
@@ -1,0 +1,23 @@
+import fixture
+
+
+def test_standard_verbosity():
+    stderr = fixture.start_tangelo(stderr=True)
+    stderr = '\n'.join(stderr)
+
+    print stderr
+
+    assert 'TANGELO Server is running' in stderr
+    assert 'TANGELO Hostname' in stderr
+    fixture.stop_tangelo()
+
+
+def test_lower_verbosity():
+    stderr = fixture.start_tangelo("-q", stderr=True)
+    stderr = '\n'.join(stderr)
+
+    print stderr
+
+    assert 'TANGELO Server is running' in stderr
+    assert 'TANGELO Hostname' not in stderr
+    fixture.stop_tangelo()

--- a/tests/tangelo-verbose.py
+++ b/tests/tangelo-verbose.py
@@ -5,8 +5,6 @@ def test_standard_verbosity():
     stderr = fixture.start_tangelo(stderr=True)
     stderr = '\n'.join(stderr)
 
-    print stderr
-
     assert 'TANGELO Server is running' in stderr
     assert 'TANGELO Hostname' in stderr
     fixture.stop_tangelo()
@@ -15,8 +13,6 @@ def test_standard_verbosity():
 def test_lower_verbosity():
     stderr = fixture.start_tangelo("-q", stderr=True)
     stderr = '\n'.join(stderr)
-
-    print stderr
 
     assert 'TANGELO Server is running' in stderr
     assert 'TANGELO Hostname' not in stderr


### PR DESCRIPTION
Hithertofore, the verbosity option did nothing.  We now default to a log level of INFO, and adding --verbose or -v increases the log level.  Adding --quiet or -q decreases the log level.  Added a tangelo.log_debug method, and tangelo.log can have a lvl specified.