### PR TITLE
Allow json instead of a file for config.

### DIFF
--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -57,6 +57,12 @@ with the ``-c`` or ``--config`` option: ::
 
     tangelo -c ~/myconfig.yaml
 
+Alternately, instead of using a yaml file, the configuration can be specified as a JSON string ::
+
+    tangelo -c '{"plugins":[{"name":"ui"}]}'
+
+Strictly, if the value passed to the config option is *not* the name of an existing file *and* starts with a ``{``, then it is expected to be a valid YAML or JSON string.
+
 When the flag is omitted, Tangelo will use default values for all
 configuration options (see :ref:`config-options` below).
 

--- a/docs/tangelo-manpage.rst
+++ b/docs/tangelo-manpage.rst
@@ -13,7 +13,7 @@ Start a Tangelo server.
 Optional argument                  Effect
 =================================  ============================================================================================================================
 -h, --help                         show this help message and exit
--c FILE, --config FILE             specifies configuration file to use
+-c FILE, --config FILE             specifies configuration file or json string to use
 -nc, --no-config                   skips looking for and using a configuration file
 -a, --access-auth                  enable HTTP authentication (i.e. processing of .htaccess files) (default)
 -na, --no-access-auth              disable HTTP authentication (i.e. processing of .htaccess files)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [flake8]
-ignore = E501,E402
+ignore = E501,E402,D100,D101,D102,D103,D205,D400,C901

--- a/tangelo/tangelo/__main__.py
+++ b/tangelo/tangelo/__main__.py
@@ -196,7 +196,7 @@ def get_tangelo_ico():
 
 def main():
     p = argparse.ArgumentParser(description="Start a Tangelo server.")
-    p.add_argument("-c", "--config", type=str, default=None, metavar="FILE", help="specifies configuration file to use")
+    p.add_argument("-c", "--config", type=str, default=None, metavar="FILE", help="specifies configuration file or json string to use")
     p.add_argument("-a", "--access-auth", action="store_const", const=True, default=None, help="enable HTTP authentication (i.e. processing of .htaccess files) (default)")
     p.add_argument("-na", "--no-access-auth", action="store_const", const=True, default=None, help="disable HTTP authentication (i.e. processing of .htaccess files)")
     p.add_argument("-p", "--drop-privileges", action="store_const", const=True, default=None, help="enable privilege drop when started as superuser (default)")
@@ -258,8 +258,11 @@ def main():
     if cfg_file is None:
         tangelo.log("TANGELO", "No configuration file specified - using command line args and defaults")
     else:
-        cfg_file = tangelo.util.expandpath(cfg_file)
-        tangelo.log("TANGELO", "Using configuration file %s" % (cfg_file))
+        if os.path.exists(tangelo.util.expandpath(cfg_file)) or not cfg_file.startswith('{'):
+            cfg_file = tangelo.util.expandpath(cfg_file)
+            tangelo.log("TANGELO", "Using configuration file %s" % (cfg_file))
+        else:
+            tangelo.log("TANGELO", "Using configuration string")
 
     # Parse the config file; report errors if any.
     try:

--- a/tangelo/tangelo/util.py
+++ b/tangelo/tangelo/util.py
@@ -19,9 +19,15 @@ def windows():
 
 
 def yaml_safe_load(filename, type=None):
-    with open(filename) as f:
+    if os.path.exists(filename) or not filename.startswith('{'):
+        with open(filename) as f:
+            try:
+                data = yaml.safe_load(f.read())
+            except yaml.YAMLError as e:
+                raise ValueError(e)
+    else:
         try:
-            data = yaml.safe_load(f.read())
+            data = yaml.safe_load(filename)
         except yaml.YAMLError as e:
             raise ValueError(e)
 

--- a/tests/fixture/__init__.py
+++ b/tests/fixture/__init__.py
@@ -28,6 +28,7 @@ def relative_path(path):
 
 def run_tangelo(*args, **kwargs):
     timeout = kwargs.get("timeout", 5)
+    terminate = kwargs.get("terminate", False)
     tangelo = ["venv/Scripts/python", "venv/Scripts/tangelo"] if windows() else ["venv/bin/tangelo"]
 
     # Start Tangelo with the specified arguments, and immediately poll the
@@ -41,6 +42,9 @@ def run_tangelo(*args, **kwargs):
         time.sleep(0.5)
         proc.poll()
         now = datetime.datetime.now()
+
+    if terminate:
+        proc.terminate()
 
     return (proc.returncode, filter(None, proc.stdout.read().splitlines()), filter(None, proc.stderr.read().splitlines()))
 

--- a/tests/fixture/__init__.py
+++ b/tests/fixture/__init__.py
@@ -43,7 +43,7 @@ def run_tangelo(*args, **kwargs):
         proc.poll()
         now = datetime.datetime.now()
 
-    if terminate:
+    if proc.poll() is None and terminate:
         proc.terminate()
 
     return (proc.returncode, filter(None, proc.stdout.read().splitlines()), filter(None, proc.stderr.read().splitlines()))

--- a/tests/tangelo-config.py
+++ b/tests/tangelo-config.py
@@ -1,4 +1,5 @@
 import fixture
+import json
 
 
 def test_bad_config():
@@ -23,3 +24,12 @@ def test_non_dict_config():
 
     assert len(stderr) > 1
     assert signal in stderr[1]
+
+
+def test_inline_config():
+    config = {"plugins": [{"name": "ui"}]}
+    stderr = fixture.start_tangelo('-c', json.dumps(config), stderr=True)
+    stderr = '\n'.join(stderr)
+    fixture.stop_tangelo()
+    assert 'TANGELO Server is running' in stderr
+    assert 'TANGELO Plugin ui loaded' in stderr

--- a/tests/tangelo-config.py
+++ b/tests/tangelo-config.py
@@ -28,8 +28,10 @@ def test_non_dict_config():
 
 def test_inline_config():
     config = {"plugins": [{"name": "ui"}]}
-    (_, _, stderr) = fixture.run_tangelo('-c', json.dumps(config), terminate=True)
-    stderr = '\n'.join(stderr)
+    (_, _, stderr) = fixture.run_tangelo("-c", json.dumps(config), terminate=True)
+    stderr = "\n".join(stderr)
 
-    assert 'TANGELO Server is running' in stderr
-    assert 'TANGELO Plugin ui loaded' in stderr
+    print stderr
+
+    assert "TANGELO Server is running" in stderr
+    assert "TANGELO Plugin ui loaded" in stderr

--- a/tests/tangelo-config.py
+++ b/tests/tangelo-config.py
@@ -28,8 +28,8 @@ def test_non_dict_config():
 
 def test_inline_config():
     config = {"plugins": [{"name": "ui"}]}
-    stderr = fixture.start_tangelo('-c', json.dumps(config), stderr=True)
+    (_, _, stderr) = fixture.run_tangelo('-c', json.dumps(config), terminate=True)
     stderr = '\n'.join(stderr)
-    fixture.stop_tangelo()
+
     assert 'TANGELO Server is running' in stderr
     assert 'TANGELO Plugin ui loaded' in stderr


### PR DESCRIPTION
--config has required a yaml file.  If, instead of a file, a string is specified that begins with an open brace {, AND a file with that exact name does not exist, try to parse that string as yaml and use that as the configuration.

This was added on top of the `enable-verbosity` branch.  It could be rebased to `develop` if desired.