### PR TITLE
Change how plugin python modules are imported.

### DIFF
--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -11,6 +11,11 @@ behaviors.  Tangelo ships with several bundled plugins that implement useful
 features and provide examples of how the plugin system can add value to your
 Tangelo setup.
 
+Plugins are loaded in the order listed in the tangelo configuration.  If one
+plugin is dependent on another plugin being loaded before it can be
+initialized, be sure to place the dependent plugin after the plugin it
+requires.
+
 Structure and Content
 =====================
 
@@ -60,8 +65,11 @@ more information).
 Python Content
 --------------
 
-A plugin may also wish to export some Python code for use in web services.  In
-the foobar plugin example, such content appears in
+A plugin may also wish to export some Python code for use in web services.
+The ``python`` directory or a ``python.py`` file within a plugin is imported
+as a module in the ``tangelo.plugin`` namespace with the plugin's name.
+
+In the foobar plugin example, such content appears in
 ``foobar/python/__init__.py``.  This file, for example, might contain the
 following code:
 
@@ -80,7 +88,8 @@ functions as in the following example:
 .. code-block:: python
 
     import tangelo
-    import tangelo.plugin.foobar
+    # It isn't necessary to explicitly import tangelo.plugin.foobar, as it is
+    # added to the tangelo.plugin namespace when tangelo starts.
 
     def run(n):
         tangelo.content_type("text/plain")

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -57,6 +57,12 @@ with the ``-c`` or ``--config`` option: ::
 
     tangelo -c ~/myconfig.yaml
 
+Alternately, instead of using a yaml file, the configuration can be specified as a JSON string ::
+
+    tangelo -c '{"plugins":[{"name":"ui"}]}'
+
+Strictly, if the value passed to the config option is *not* the name of an existing file *and* starts with a ``{``, then it is expected to be a valid YAML or JSON string.
+
 When the flag is omitted, Tangelo will use default values for all
 configuration options (see :ref:`config-options` below).
 

--- a/docs/tangelo-manpage.rst
+++ b/docs/tangelo-manpage.rst
@@ -13,7 +13,7 @@ Start a Tangelo server.
 Optional argument                  Effect
 =================================  ============================================================================================================================
 -h, --help                         show this help message and exit
--c FILE, --config FILE             specifies configuration file to use
+-c FILE, --config FILE             specifies configuration file or json string to use
 -nc, --no-config                   skips looking for and using a configuration file
 -a, --access-auth                  enable HTTP authentication (i.e. processing of .htaccess files) (default)
 -na, --no-access-auth              disable HTTP authentication (i.e. processing of .htaccess files)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [flake8]
-ignore = E501,E402
+ignore = E501,E402,D100,D101,D102,D103,D205,D400,C901

--- a/tangelo/tangelo/__main__.py
+++ b/tangelo/tangelo/__main__.py
@@ -196,7 +196,7 @@ def get_tangelo_ico():
 
 def main():
     p = argparse.ArgumentParser(description="Start a Tangelo server.")
-    p.add_argument("-c", "--config", type=str, default=None, metavar="FILE", help="specifies configuration file to use")
+    p.add_argument("-c", "--config", type=str, default=None, metavar="FILE", help="specifies configuration file or json string to use")
     p.add_argument("-a", "--access-auth", action="store_const", const=True, default=None, help="enable HTTP authentication (i.e. processing of .htaccess files) (default)")
     p.add_argument("-na", "--no-access-auth", action="store_const", const=True, default=None, help="disable HTTP authentication (i.e. processing of .htaccess files)")
     p.add_argument("-p", "--drop-privileges", action="store_const", const=True, default=None, help="enable privilege drop when started as superuser (default)")
@@ -258,8 +258,11 @@ def main():
     if cfg_file is None:
         tangelo.log("TANGELO", "No configuration file specified - using command line args and defaults")
     else:
-        cfg_file = tangelo.util.expandpath(cfg_file)
-        tangelo.log("TANGELO", "Using configuration file %s" % (cfg_file))
+        if os.path.exists(tangelo.util.expandpath(cfg_file)) or not cfg_file.startswith('{'):
+            cfg_file = tangelo.util.expandpath(cfg_file)
+            tangelo.log("TANGELO", "Using configuration file %s" % (cfg_file))
+        else:
+            tangelo.log("TANGELO", "Using configuration string")
 
     # Parse the config file; report errors if any.
     try:

--- a/tangelo/tangelo/util.py
+++ b/tangelo/tangelo/util.py
@@ -19,9 +19,15 @@ def windows():
 
 
 def yaml_safe_load(filename, type=None):
-    with open(filename) as f:
+    if os.path.exists(filename) or not filename.startswith('{'):
+        with open(filename) as f:
+            try:
+                data = yaml.safe_load(f.read())
+            except yaml.YAMLError as e:
+                raise ValueError(e)
+    else:
         try:
-            data = yaml.safe_load(f.read())
+            data = yaml.safe_load(filename)
         except yaml.YAMLError as e:
             raise ValueError(e)
 

--- a/tests/fixture/__init__.py
+++ b/tests/fixture/__init__.py
@@ -28,6 +28,7 @@ def relative_path(path):
 
 def run_tangelo(*args, **kwargs):
     timeout = kwargs.get("timeout", 5)
+    terminate = kwargs.get("terminate", False)
     tangelo = ["venv/Scripts/python", "venv/Scripts/tangelo"] if windows() else ["venv/bin/tangelo"]
 
     # Start Tangelo with the specified arguments, and immediately poll the
@@ -41,6 +42,9 @@ def run_tangelo(*args, **kwargs):
         time.sleep(0.5)
         proc.poll()
         now = datetime.datetime.now()
+
+    if terminate:
+        proc.terminate()
 
     return (proc.returncode, filter(None, proc.stdout.read().splitlines()), filter(None, proc.stderr.read().splitlines()))
 

--- a/tests/fixture/__init__.py
+++ b/tests/fixture/__init__.py
@@ -43,7 +43,7 @@ def run_tangelo(*args, **kwargs):
         proc.poll()
         now = datetime.datetime.now()
 
-    if terminate:
+    if proc.poll() is None and terminate:
         proc.terminate()
 
     return (proc.returncode, filter(None, proc.stdout.read().splitlines()), filter(None, proc.stderr.read().splitlines()))

--- a/tests/fixture/__init__.py
+++ b/tests/fixture/__init__.py
@@ -90,6 +90,8 @@ def start_tangelo():
             return 0
         elif line.rstrip().endswith("ENGINE Bus EXITED") or process.poll() is not None:
             process = None
+            if kwargs.get('stderr', False):
+                return None, buf
             raise RuntimeError("Could not start Tangelo:\n%s" % ("".join(buf)))
 
 

--- a/tests/fixture/__init__.py
+++ b/tests/fixture/__init__.py
@@ -4,8 +4,8 @@ import platform
 import subprocess
 import time
 
-host = "localhost"
-port = "50047"
+host = "127.0.0.1"
+port = "30047"
 
 process = None
 
@@ -33,7 +33,10 @@ def run_tangelo(*args, **kwargs):
 
     # Start Tangelo with the specified arguments, and immediately poll the
     # process to bootstrap its returncode state.
-    proc = subprocess.Popen(tangelo + list(args), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    proc = subprocess.Popen(tangelo + [
+        '--host', host,
+        '--port', port,
+    ] + list(args), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     proc.poll()
 
     # Run in a loop until the timeout expires or the process ends.
@@ -90,8 +93,6 @@ def start_tangelo():
             return 0
         elif line.rstrip().endswith("ENGINE Bus EXITED") or process.poll() is not None:
             process = None
-            if kwargs.get('stderr', False):
-                return None, buf
             raise RuntimeError("Could not start Tangelo:\n%s" % ("".join(buf)))
 
 

--- a/tests/plugin-import.py
+++ b/tests/plugin-import.py
@@ -1,0 +1,59 @@
+import fixture
+import json
+
+
+def test_plugin_module():
+    config = {'plugins': [{
+        'name': 'moduletest',
+        'path': 'tests/plugins/moduletest'
+    }]}
+    stderr = fixture.start_tangelo('--config', json.dumps(config), stderr=True)
+    stderr = '\n'.join(stderr)
+    fixture.stop_tangelo()
+
+    assert 'Plugin has value server.TestConstant True' in stderr
+
+
+def test_plugin_single_file():
+    config = {'plugins': [{
+        'name': 'pythonfile',
+        'path': 'tests/plugins/pythonfile'
+    }]}
+    stderr = fixture.start_tangelo('--config', json.dumps(config), stderr=True)
+    stderr = '\n'.join(stderr)
+    fixture.stop_tangelo()
+
+    assert 'Python file plugin' in stderr
+
+
+def test_plugin_order_good():
+    config = {'plugins': [{
+        'name': 'moduletest',
+        'path': 'tests/plugins/moduletest'
+    }, {
+        'name': 'pluginorder',
+        'path': 'tests/plugins/pluginorder'
+    }]}
+    stderr = fixture.start_tangelo('--config', json.dumps(config), stderr=True)
+    stderr = '\n'.join(stderr)
+    fixture.stop_tangelo()
+
+    assert 'Plugin can reference tangelo.plugin.moduletest True' in stderr
+
+
+def test_plugin_order_bad():
+    config = {'plugins': [{
+        'name': 'pluginorder',
+        'path': 'tests/plugins/pluginorder'
+    }, {
+        'name': 'moduletest',
+        'path': 'tests/plugins/moduletest'
+    }]}
+    res = fixture.start_tangelo('--config', json.dumps(config), stderr=True)
+
+    if not isinstance(res, tuple):
+        fixture.stop_tangelo()
+        assert 'Tangelo started when we expected it to fail' is False
+    stderr = '\n'.join(res[1])
+
+    assert 'Plugin can reference tangelo.plugin.moduletest True' not in stderr

--- a/tests/plugin-import.py
+++ b/tests/plugin-import.py
@@ -7,9 +7,8 @@ def test_plugin_module():
         'name': 'moduletest',
         'path': 'tests/plugins/moduletest'
     }]}
-    stderr = fixture.start_tangelo('--config', json.dumps(config), stderr=True)
+    (_, _, stderr) = fixture.run_tangelo('--config', json.dumps(config), timeout=3, terminate=True)
     stderr = '\n'.join(stderr)
-    fixture.stop_tangelo()
 
     assert 'Plugin has value server.TestConstant True' in stderr
 
@@ -19,9 +18,8 @@ def test_plugin_single_file():
         'name': 'pythonfile',
         'path': 'tests/plugins/pythonfile'
     }]}
-    stderr = fixture.start_tangelo('--config', json.dumps(config), stderr=True)
+    (_, _, stderr) = fixture.run_tangelo('--config', json.dumps(config), timeout=3, terminate=True)
     stderr = '\n'.join(stderr)
-    fixture.stop_tangelo()
 
     assert 'Python file plugin' in stderr
 
@@ -34,9 +32,8 @@ def test_plugin_order_good():
         'name': 'pluginorder',
         'path': 'tests/plugins/pluginorder'
     }]}
-    stderr = fixture.start_tangelo('--config', json.dumps(config), stderr=True)
+    (_, _, stderr) = fixture.run_tangelo('--config', json.dumps(config), timeout=3, terminate=True)
     stderr = '\n'.join(stderr)
-    fixture.stop_tangelo()
 
     assert 'Plugin can reference tangelo.plugin.moduletest True' in stderr
 

--- a/tests/plugin-import.py
+++ b/tests/plugin-import.py
@@ -3,50 +3,50 @@ import json
 
 
 def test_plugin_module():
-    config = {'plugins': [{
-        'name': 'moduletest',
-        'path': 'tests/plugins/moduletest'
+    config = {"plugins": [{
+        "name": "moduletest",
+        "path": "tests/plugins/moduletest"
     }]}
-    (_, _, stderr) = fixture.run_tangelo('--config', json.dumps(config), timeout=3, terminate=True)
-    stderr = '\n'.join(stderr)
+    (_, _, stderr) = fixture.run_tangelo("--config", json.dumps(config), timeout=3, terminate=True)
+    stderr = "\n".join(stderr)
 
-    assert 'Plugin has value server.TestConstant True' in stderr
+    assert "Plugin has value server.TestConstant True" in stderr
 
 
 def test_plugin_single_file():
-    config = {'plugins': [{
-        'name': 'pythonfile',
-        'path': 'tests/plugins/pythonfile'
+    config = {"plugins": [{
+        "name": "pythonfile",
+        "path": "tests/plugins/pythonfile"
     }]}
-    (_, _, stderr) = fixture.run_tangelo('--config', json.dumps(config), timeout=3, terminate=True)
-    stderr = '\n'.join(stderr)
+    (_, _, stderr) = fixture.run_tangelo("--config", json.dumps(config), timeout=3, terminate=True)
+    stderr = "\n".join(stderr)
 
-    assert 'Python file plugin' in stderr
+    assert "Python file plugin" in stderr
 
 
 def test_plugin_order_good():
-    config = {'plugins': [{
-        'name': 'moduletest',
-        'path': 'tests/plugins/moduletest'
+    config = {"plugins": [{
+        "name": "moduletest",
+        "path": "tests/plugins/moduletest"
     }, {
-        'name': 'pluginorder',
-        'path': 'tests/plugins/pluginorder'
+        "name": "pluginorder",
+        "path": "tests/plugins/pluginorder"
     }]}
-    (_, _, stderr) = fixture.run_tangelo('--config', json.dumps(config), timeout=3, terminate=True)
-    stderr = '\n'.join(stderr)
+    (_, _, stderr) = fixture.run_tangelo("--config", json.dumps(config), timeout=3, terminate=True)
+    stderr = "\n".join(stderr)
 
-    assert 'Plugin can reference tangelo.plugin.moduletest True' in stderr
+    assert "Plugin can reference tangelo.plugin.moduletest True" in stderr
 
 
 def test_plugin_order_bad():
-    config = {'plugins': [{
-        'name': 'pluginorder',
-        'path': 'tests/plugins/pluginorder'
+    config = {"plugins": [{
+        "name": "pluginorder",
+        "path": "tests/plugins/pluginorder"
     }, {
-        'name': 'moduletest',
-        'path': 'tests/plugins/moduletest'
+        "name": "moduletest",
+        "path": "tests/plugins/moduletest"
     }]}
-    (_, _, stderr) = fixture.run_tangelo('--config', json.dumps(config), timeout=3, terminate=True)
+    (_, _, stderr) = fixture.run_tangelo("--config", json.dumps(config), timeout=3, terminate=True)
     stderr = "\n".join(stderr)
 
     assert "Plugin pluginorder failed to load" in stderr

--- a/tests/plugin-import.py
+++ b/tests/plugin-import.py
@@ -46,11 +46,7 @@ def test_plugin_order_bad():
         'name': 'moduletest',
         'path': 'tests/plugins/moduletest'
     }]}
-    res = fixture.start_tangelo('--config', json.dumps(config), stderr=True)
+    (_, _, stderr) = fixture.run_tangelo('--config', json.dumps(config), timeout=3, terminate=True)
+    stderr = "\n".join(stderr)
 
-    if not isinstance(res, tuple):
-        fixture.stop_tangelo()
-        assert 'Tangelo started when we expected it to fail' is False
-    stderr = '\n'.join(res[1])
-
-    assert 'Plugin can reference tangelo.plugin.moduletest True' not in stderr
+    assert "Plugin pluginorder failed to load" in stderr

--- a/tests/plugin-import.py
+++ b/tests/plugin-import.py
@@ -2,6 +2,12 @@ import fixture
 import json
 
 
+moduletest = {"name": "moduletest",
+              "path": "tests/plugins/moduletest"}
+pluginorder = {"name": "pluginorder",
+               "path": "tests/plugins/pluginorder"}
+
+
 def test_plugin_module():
     config = {"plugins": [{
         "name": "moduletest",
@@ -25,13 +31,9 @@ def test_plugin_single_file():
 
 
 def test_plugin_order_good():
-    config = {"plugins": [{
-        "name": "moduletest",
-        "path": "tests/plugins/moduletest"
-    }, {
-        "name": "pluginorder",
-        "path": "tests/plugins/pluginorder"
-    }]}
+    config = {"plugins": [moduletest,
+                          pluginorder]}
+
     (_, _, stderr) = fixture.run_tangelo("--config", json.dumps(config), timeout=3, terminate=True)
     stderr = "\n".join(stderr)
 
@@ -39,13 +41,9 @@ def test_plugin_order_good():
 
 
 def test_plugin_order_bad():
-    config = {"plugins": [{
-        "name": "pluginorder",
-        "path": "tests/plugins/pluginorder"
-    }, {
-        "name": "moduletest",
-        "path": "tests/plugins/moduletest"
-    }]}
+    config = {"plugins": [pluginorder,
+                          moduletest]}
+
     (_, _, stderr) = fixture.run_tangelo("--config", json.dumps(config), timeout=3, terminate=True)
     stderr = "\n".join(stderr)
 

--- a/tests/plugins/moduletest/python/__init__.py
+++ b/tests/plugins/moduletest/python/__init__.py
@@ -1,0 +1,3 @@
+import server
+import tangelo
+tangelo.log('Plugin has value server.TestConstant %s' % str(server.TestConstant))

--- a/tests/plugins/moduletest/python/server.py
+++ b/tests/plugins/moduletest/python/server.py
@@ -1,0 +1,1 @@
+TestConstant = True

--- a/tests/plugins/pluginorder/python/__init__.py
+++ b/tests/plugins/pluginorder/python/__init__.py
@@ -1,0 +1,4 @@
+import tangelo
+
+modtest = tangelo.plugin.moduletest.server.TestConstant
+tangelo.log('Plugin can reference tangelo.plugin.moduletest %s' % str(modtest))

--- a/tests/plugins/pythonfile/python.py
+++ b/tests/plugins/pythonfile/python.py
@@ -1,0 +1,4 @@
+import tangelo
+
+tangelo.log('Python file plugin')
+tangelo.log('This doesn\'t use a Python module directory.')

--- a/tests/tangelo-config.py
+++ b/tests/tangelo-config.py
@@ -1,4 +1,5 @@
 import fixture
+import json
 
 
 def test_bad_config():
@@ -23,3 +24,12 @@ def test_non_dict_config():
 
     assert len(stderr) > 1
     assert signal in stderr[1]
+
+
+def test_inline_config():
+    config = {"plugins": [{"name": "ui"}]}
+    stderr = fixture.start_tangelo('-c', json.dumps(config), stderr=True)
+    stderr = '\n'.join(stderr)
+    fixture.stop_tangelo()
+    assert 'TANGELO Server is running' in stderr
+    assert 'TANGELO Plugin ui loaded' in stderr

--- a/tests/tangelo-config.py
+++ b/tests/tangelo-config.py
@@ -28,8 +28,10 @@ def test_non_dict_config():
 
 def test_inline_config():
     config = {"plugins": [{"name": "ui"}]}
-    (_, _, stderr) = fixture.run_tangelo('-c', json.dumps(config), terminate=True)
-    stderr = '\n'.join(stderr)
+    (_, _, stderr) = fixture.run_tangelo("-c", json.dumps(config), terminate=True)
+    stderr = "\n".join(stderr)
 
-    assert 'TANGELO Server is running' in stderr
-    assert 'TANGELO Plugin ui loaded' in stderr
+    print stderr
+
+    assert "TANGELO Server is running" in stderr
+    assert "TANGELO Plugin ui loaded" in stderr

--- a/tests/tangelo-config.py
+++ b/tests/tangelo-config.py
@@ -28,8 +28,8 @@ def test_non_dict_config():
 
 def test_inline_config():
     config = {"plugins": [{"name": "ui"}]}
-    stderr = fixture.start_tangelo('-c', json.dumps(config), stderr=True)
+    (_, _, stderr) = fixture.run_tangelo('-c', json.dumps(config), terminate=True)
     stderr = '\n'.join(stderr)
-    fixture.stop_tangelo()
+
     assert 'TANGELO Server is running' in stderr
     assert 'TANGELO Plugin ui loaded' in stderr


### PR DESCRIPTION
Use imp functions to import plugins.

This prevents printing a warning when the plugin imports a python module.  It also allows a plugin to have a single python file called python.py instead of a module in python (python/__init__.py).

Ensure plugins start in the order listed.  This allows plugins with dependencies on other plugins.

Note that the tests are dependent on PR #526.