### PR TITLE
Handle settings from config.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ versioning](http://semver.org).
 - Service functions ``tangelo.redirect()`` and ``tangelo.internal_redirect()``
   to allow services to redirect to other resources
 - Service function ``tangelo.file()`` to serve arbitrary files
+- Process settings from configuration during startup.  Settings can be used to pass information to the server.
+- Change some settings while running.
 
 ### Changed
 - Documentation introduction is more focused; tutorials are more

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -102,7 +102,9 @@ key              The path to the SSL key                                        
 
 cert             The path to the SSL certificate                                     ``None`` [#https]_ [#unset]_
 
-plugins          A list of plugins to load (see :ref:`plugin-config`)                ``None`` [#plugins]_ [#unset]_
+plugins          A list of plugins to load (see :ref:`plugin-config`)                ``None`` [#plugins_config]_ [#unset]_
+
+settings         A list of settings to apply as Tangelo is starting.                 ``None`` [#settings]_ [#unset]_
 ================ =================================================================   =================================
 
 .. rubric:: Footnotes
@@ -124,8 +126,21 @@ plugins          A list of plugins to load (see :ref:`plugin-config`)           
 .. [#unset] That is to say, the option is simply unset by default, the
     equivalent of not mentioning the option at all in a configuration file.
 
-.. [#plugins] This option can *only* appear in the configuration file; there is
+.. [#plugins_config] This option can *only* appear in the configuration file; there is
     no command line equivalent.
+
+.. [#settings] This option provides a method for changing server related
+    settings.  For instance, using
+
+    .. code-block:: yaml
+
+        settings:
+          -
+            server:
+              server.thread_pool: 1000
+
+    would signal the internal server to adjust the number of simultaneous 
+    requests that can be processed.
 
 Administering a Tangelo Installation
 ====================================

--- a/tangelo/tangelo/__main__.py
+++ b/tangelo/tangelo/__main__.py
@@ -111,6 +111,7 @@ class Config(object):
                "key": types.StringTypes,
                "cert": types.StringTypes,
                "root": types.StringTypes,
+               "settings": [list, dict],
                "plugins": [list]}
 
     def __init__(self, filename):
@@ -299,6 +300,25 @@ def main():
         for message in config.errors:
             tangelo.log_critical("TANGELO", message)
         return 1
+
+    # Process config file settings
+    if getattr(config, "settings", None):
+        settings = config.settings
+        if not isinstance(settings, list):
+            settings = [settings]
+        for setting in settings:
+            if not isinstance(setting, dict):
+                tangelo.log_warning("TANGELO", "Can't process setting %s" % (
+                    setting))
+                continue
+            for settingkey in setting:
+                if isinstance(setting[settingkey], dict):
+                    for subsettingkey in setting[settingkey]:
+                        tangelo.util.set_setting(
+                            settingkey + "." + subsettingkey,
+                            setting[settingkey][subsettingkey])
+                else:
+                    tangelo.util.set_setting(settingkey, setting[settingkey])
 
     # Determine whether to use access auth.
     access_auth = True

--- a/tests/tangelo-config-settings.py
+++ b/tests/tangelo-config-settings.py
@@ -1,0 +1,64 @@
+import fixture
+import json
+import nose
+import requests
+
+
+def start_tangelo():
+    """Start tangelo with a some settings."""
+    config = {"settings": [{"server": {"server.thread_pool": 1000}}]}
+    return fixture.start_tangelo("-c", json.dumps(config))
+
+
+@nose.with_setup(start_tangelo, fixture.stop_tangelo)
+def test_config_settings():
+    response = requests.get(fixture.url('settings'))
+    print response
+    assert 'pool="1000"' in response
+
+
+@nose.with_setup(start_tangelo, fixture.stop_tangelo)
+def test_config_settings_change():
+    response = requests.get(fixture.url('settings', pool='500'))
+    print response
+    assert 'pool="500"' in response
+
+
+@nose.with_setup(fixture.start_tangelo, fixture.stop_tangelo)
+def test_config_no_settings():
+    response = requests.get(fixture.url('settings'))
+    print response
+    assert 'pool="None"' in response
+
+
+def test_config_wrong_type_settings():
+    config = {"settings": "Angosian"}
+    (_, _, stderr) = fixture.run_tangelo(
+        "-c", json.dumps(config), terminate=True)
+    stderr = "\n".join(stderr)
+
+    print stderr
+
+    assert "option settings must be of type list or dict" in stderr
+
+
+def test_config_bad_settings():
+    config = {"settings": ["Angosian"]}
+    (_, _, stderr) = fixture.run_tangelo(
+        "-c", json.dumps(config), terminate=True)
+    stderr = "\n".join(stderr)
+
+    print stderr
+
+    assert "Can't process setting Angosian" in stderr
+
+
+def test_config_unknown_settings():
+    config = {"settings": [{"unknown": {"Angosian": "Tarsian"}}]}
+    (_, _, stderr) = fixture.run_tangelo(
+        "-c", json.dumps(config), terminate=True)
+    stderr = "\n".join(stderr)
+
+    print stderr
+
+    assert "Setting unknown.Angosian was ignored." in stderr

--- a/tests/web/settings.py
+++ b/tests/web/settings.py
@@ -1,0 +1,11 @@
+import cherrypy
+import tangelo
+
+
+# This service reports the value of cherrypy's thread pool setting
+def run(**kwargs):
+    if kwargs.get('pool'):
+        tangelo.util.set_setting('server.server.thread_pool',
+                                 int(kwargs['pool']))
+    response = 'pool="%r"' % cherrypy.config.get('server.thread_pool')
+    return response


### PR DESCRIPTION
Added settings processing from the config file and an internal set_setting utility function.  This can be used to set cherrypy settings.

Addresses issue #532.